### PR TITLE
Swagger Init

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "nestjs-zod": "^5.1.1",
     "@repo/common": "*",
     "dotenv": "^17.3.1",
     "reflect-metadata": "^0.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,9 +24,10 @@
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
-    "nestjs-zod": "^5.1.1",
+    "@nestjs/swagger": "^11.2.6",
     "@repo/common": "*",
     "dotenv": "^17.3.1",
+    "nestjs-zod": "^5.1.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Redirect } from "@nestjs/common";
 import { AppService } from "./app.service";
 import type { HelloWorld } from "@repo/common";
 
@@ -7,7 +7,6 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): HelloWorld {
-    return this.appService.getHello();
-  }
+  @Redirect("/docs", 301)
+  root(): void {}
 }

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { DbService } from "./db.service";
-import { Event } from "@repo/common";
+import { EventDto } from "../dto/dto";
 
 @Injectable()
 export class EventDatabaseService {
@@ -8,17 +8,17 @@ export class EventDatabaseService {
   constructor(private db: DbService) {}
 
   /**
-   * Get a single Event by their ID.
+   * Get a single EventDto by their ID.
    * @param id The ID we're trying to fetch.
-   * @returns The Event if there is one.
+   * @returns The EventDto if there is one.
    */
   // TODO: return multiple events with same production id
-  async getEventById(id: number): Promise<Event> {
-    const events: Event[] = await this.getEvents({ id: id });
+  async getEventById(id: number): Promise<EventDto> {
+    const events: EventDto[] = await this.getEvents({ id: id });
     if (events.length === 0)
-      throw new BadRequestException(`No Event exists for provided ID(${id})`);
+      throw new BadRequestException(`No EventDto exists for provided ID(${id})`);
 
-    return events[0]; // There should be an Event in here if the length is not 0.
+    return events[0]; // There should be an EventDto in here if the length is not 0.
   }
 
   // generic GET function (used only as intermediary end-point)
@@ -30,7 +30,7 @@ export class EventDatabaseService {
       hall: string;
       id: number;
     }>,
-  ): Promise<Event[]> {
+  ): Promise<EventDto[]> {
     const conditions: string[] = [];
     const values: any[] = [];
     let i = 1;
@@ -79,11 +79,11 @@ export class EventDatabaseService {
       ORDER BY e.starttime
         `;
 
-    return this.db.query<Event>(query, values);
+    return this.db.query<EventDto>(query, values);
   }
 
   // generic PUT function (used only as intermediary end-point)
-  async createEvent(event: Omit<Event, "id">): Promise<Event> {
+  async createEvent(event: Omit<EventDto, "id">): Promise<EventDto> {
     // Validate input, throw error if not all
     if (!event.starttime || !event.hall || !event.production_id) {
       throw new BadRequestException("Missing required fields");
@@ -95,7 +95,7 @@ export class EventDatabaseService {
       RETURNING id, starttime, endtime, hall, production_id, price
     `;
 
-    const result = await this.db.query<Event>(query, [
+    const result = await this.db.query<EventDto>(query, [
       event.starttime,
       event.endtime,
       event.hall,
@@ -112,13 +112,13 @@ export class EventDatabaseService {
   }
 
   // generic POST function
-  async updateEvent(event: Omit<Event, "id">): Promise<Event> {
+  async updateEvent(event: Omit<EventDto, "id">): Promise<EventDto> {
     // TODO this needed?
     return new Promise(async (resolve, reject) => {});
   }
 
   // generic DELETE function
-  async deleteEvent(id: number, date: string): Promise<Event> {
+  async deleteEvent(id: number, date: string): Promise<EventDto> {
     // TODO this needed?
     // + wouldnt work on id would need id and date?
     return new Promise(async (resolve, reject) => {});

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -4,25 +4,26 @@ import {
   NotFoundException,
 } from "@nestjs/common";
 import { DbService } from "./db.service";
-import { Production, ProductionSchema } from "@repo/common";
+import { ProductionDto } from "../dto/dto"; 
+import { ProductionSchema } from "@repo/common";
 
 @Injectable()
 export class ProductionDatabaseService {
   constructor(private db: DbService) {}
 
   /**
-   * Get a single Production by their ID.
+   * Get a single ProductionDto by their ID.
    * @param id The ID we are looking for.
    * @returns The production if there is one.
    */
-  async getProductionById(id: number): Promise<Production> {
-    const productions: Production[] = await this.getProductions({ id: id });
+  async getProductionById(id: number): Promise<ProductionDto> {
+    const productions: ProductionDto[] = await this.getProductions({ id: id });
     if (productions.length === 0)
       throw new BadRequestException(
-        `No Production exists for provided ID(${id})`,
+        `No ProductionDto exists for provided ID(${id})`,
       );
 
-    return productions[0]; // There should be a Production in here if the length is not 0.
+    return productions[0]; // There should be a ProductionDto in here if the length is not 0.
   }
 
   // generic GET function (used only as intermediary end-point)
@@ -35,7 +36,7 @@ export class ProductionDatabaseService {
       titel: string;
       id: number;
     }>,
-  ): Promise<Production[]> {
+  ): Promise<ProductionDto[]> {
     const conditions: string[] = [];
     const values: any[] = [];
     let i = 1;
@@ -99,11 +100,11 @@ export class ProductionDatabaseService {
       ORDER BY p.id
     `;
 
-    return this.db.query<Production>(query, values);
+    return this.db.query<ProductionDto>(query, values);
   }
 
   // generic PUT function (used only as intermediary end-point)
-  async createProduction(production: Partial<Production>): Promise<Production> {
+  async createProduction(production: Partial<ProductionDto>): Promise<ProductionDto> {
     if (!production.titel || !production.ondertitel || !production.genre) {
       throw new BadRequestException("Missing required fields");
     }
@@ -188,7 +189,7 @@ export class ProductionDatabaseService {
       ];
     }
 
-    const result = await this.db.query<Production>(query, values);
+    const result = await this.db.query<ProductionDto>(query, values);
 
     if (!result?.length) {
       throw new Error("Failed to create production");
@@ -200,8 +201,8 @@ export class ProductionDatabaseService {
   // generic POST function
   async updateProduction(
     id: number,
-    production: Omit<Production, "id">,
-  ): Promise<Production> {
+    production: Omit<ProductionDto, "id">,
+  ): Promise<ProductionDto> {
     // Validate input fields
     if (
       !production.titel ||
@@ -239,28 +240,28 @@ export class ProductionDatabaseService {
       id,
     ];
 
-    const result = await this.db.query<Production>(query, values);
+    const result = await this.db.query<ProductionDto>(query, values);
 
     if (!result || result.length === 0) {
-      throw new NotFoundException(`Production with id ${id} not found`);
+      throw new NotFoundException(`ProductionDto with id ${id} not found`);
     }
 
     return ProductionSchema.parse(result[0]);
   }
 
   // generic DELETE function
-  // TODO: Make this also remove all Events linked to this Production?
-  async deleteProduction(id: number): Promise<Production> {
+  // TODO: Make this also remove all Events linked to this ProductionDto?
+  async deleteProduction(id: number): Promise<ProductionDto> {
     const query = `
       DELETE FROM productions
       WHERE id = $1
       RETURNING *
     `;
 
-    const result = await this.db.query<Production>(query, [id]);
+    const result = await this.db.query<ProductionDto>(query, [id]);
 
     if (!result || result.length === 0) {
-      throw new NotFoundException(`Production with id ${id} not found`);
+      throw new NotFoundException(`ProductionDto with id ${id} not found`);
     }
 
     return ProductionSchema.parse(result[0]);

--- a/backend/src/dto/dto.ts
+++ b/backend/src/dto/dto.ts
@@ -1,0 +1,13 @@
+import { CreateEventSchema, CreateProductionSchema, EventSchema, ProductionSchema, UpdateEventSchema, UpdateProductionSchema } from "@repo/common";
+import { createZodDto } from "nestjs-zod";
+// This file wraps the Objects into an DTO Swagger can see.
+
+// Production Wrappers
+export class ProductionDto extends createZodDto(ProductionSchema) {}
+export class CreateProductionDto extends createZodDto(CreateProductionSchema) {}
+export class UpdateProductionDto extends createZodDto(UpdateProductionSchema) {}
+
+// Event Wrappers
+export class EventDto extends createZodDto(EventSchema) {}
+export class CreateEventDto extends createZodDto(CreateEventSchema) {}
+export class UpdateEventDto extends createZodDto(UpdateEventSchema) {}

--- a/backend/src/event/event.controller.spec.ts
+++ b/backend/src/event/event.controller.spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { EventController } from "./event.controller";
 import { EventService } from "./event.service";
-import type { Event, UpdateEvent } from "@repo/common";
+import type { EventDto, UpdateEventDto } from "../dto/dto";
 import { NotFoundException, BadRequestException } from "@nestjs/common";
 
 describe("EventController", () => {
   let controller: EventController;
   let service: EventService;
 
-  const mockEvent: Event = {
+  const mockEvent: EventDto = {
     id: 1,
     starttime: "2024-01-15T19:00:00Z",
     endtime: "2024-01-15T21:00:00Z",
@@ -17,7 +17,7 @@ describe("EventController", () => {
     price: 25,
   };
 
-  const mockEvents: Event[] = [mockEvent];
+  const mockEvents: EventDto[] = [mockEvent];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -104,7 +104,7 @@ describe("EventController", () => {
 
   describe("modifyEvent", () => {
     it("should modify and return the event", async () => {
-      const patchData: UpdateEvent = { hall: "Secondary Hall" };
+      const patchData: UpdateEventDto = { hall: "Secondary Hall" };
       const patchedEvent = { ...mockEvent, hall: "Secondary Hall" };
       
       jest.spyOn(service, "modifyEvent").mockResolvedValueOnce(patchedEvent);
@@ -115,7 +115,7 @@ describe("EventController", () => {
     });
 
     it("should throw a NotFoundException if event to modify does not exist", async () => {
-      const patchData: UpdateEvent = { hall: "Secondary Hall" };
+      const patchData: UpdateEventDto = { hall: "Secondary Hall" };
       jest.spyOn(service, "modifyEvent").mockRejectedValueOnce(new NotFoundException());
       await expect(controller.modifyEvent(999, patchData)).rejects.toThrow(NotFoundException);
     });

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -12,7 +12,7 @@ import {
 import { EventService } from "./event.service";
 import { ZodValidationPipe } from "../common/pipes/zod.validation.pipe";
 import { EventSchema, CreateEventSchema, UpdateEventSchema } from "@repo/common";
-import type { Event, CreateEvent, UpdateEvent } from "@repo/common";
+import type { EventDto, CreateEventDto, UpdateEventDto } from "../dto/dto";
 
 @Controller("event")
 export class EventController {
@@ -20,49 +20,49 @@ export class EventController {
 
   /**
    * Responds to GET /events
-   * @returns All Event objects.
+   * @returns All EventDto objects.
    */
   @Get()
-  async getAllEvents(): Promise<Event[]> {
+  async getAllEvents(): Promise<EventDto[]> {
     return await this.eventService.getAllEvents();
   }
 
   /**
    * Responds to GET /events/:id
    * @param id ID in the URL of the request.
-   * @returns The Event object with corresponding ID
+   * @returns The EventDto object with corresponding ID
    */
   // TODO: return multiple events with same production id
   @Get(":id")
-  async getEventById(@Param("id", ParseIntPipe) id: number): Promise<Event> {
+  async getEventById(@Param("id", ParseIntPipe) id: number): Promise<EventDto> {
     return await this.eventService.getEventById(id);
   }
 
   /**
    * Responds to a PUT to "/event/:id".
    * @param id ID in the URL of the request.
-   * @param event The parsed Event object.
-   * @returns The updated Event object.
+   * @param event The parsed EventDto object.
+   * @returns The updated EventDto object.
    */
   @Put(":id")
   async replaceEvent(
     @Param("id", ParseIntPipe) id: number,
-    @Body(new ZodValidationPipe(EventSchema)) event: Event,
-  ): Promise<Event> {
+    @Body(new ZodValidationPipe(EventSchema)) event: EventDto,
+  ): Promise<EventDto> {
     return await this.eventService.replaceEvent(id, event);
   }
 
   /**
    * Responds to a PATCH to "/event/:id".
    * @param id ID in the URL of the request.
-   * @param patchData The partial Event object that is used to modify.
-   * @returns The updated Event object.
+   * @param patchData The partial EventDto object that is used to modify.
+   * @returns The updated EventDto object.
    */
   @Patch(":id")
   async modifyEvent(
     @Param("id", ParseIntPipe) id: number,
-    @Body(new ZodValidationPipe(UpdateEventSchema)) patchData: UpdateEvent,
-  ): Promise<Event> {
+    @Body(new ZodValidationPipe(UpdateEventSchema)) patchData: UpdateEventDto,
+  ): Promise<EventDto> {
     return await this.eventService.modifyEvent(id, patchData);
   }
 
@@ -78,14 +78,14 @@ export class EventController {
 
   /**
    * Responds to a POST to "/event/".
-   * @param newEvent The new Event data we want to add
-   * @returns The newly created Event.
+   * @param newEvent The new EventDto data we want to add
+   * @returns The newly created EventDto.
    */
   @Post()
   @UsePipes(new ZodValidationPipe(CreateEventSchema))
   async createEvent(
-    @Body() newEvent: CreateEvent,
-  ): Promise<Event> {
+    @Body() newEvent: CreateEventDto,
+  ): Promise<EventDto> {
     return this.eventService.createEvent(newEvent);
   }
 }

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -12,7 +12,8 @@ import {
 import { EventService } from "./event.service";
 import { ZodValidationPipe } from "../common/pipes/zod.validation.pipe";
 import { EventSchema, CreateEventSchema, UpdateEventSchema } from "@repo/common";
-import type { EventDto, CreateEventDto, UpdateEventDto } from "../dto/dto";
+import { EventDto, CreateEventDto, UpdateEventDto } from "../dto/dto";
+import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 
 @Controller("event")
 export class EventController {
@@ -22,6 +23,8 @@ export class EventController {
    * Responds to GET /events
    * @returns All EventDto objects.
    */
+  @ApiOperation({ summary: "Returns all Event objects." })
+  @ApiOkResponse({ type: EventDto, isArray: true, description: "All Events returned." })
   @Get()
   async getAllEvents(): Promise<EventDto[]> {
     return await this.eventService.getAllEvents();
@@ -33,6 +36,8 @@ export class EventController {
    * @returns The EventDto object with corresponding ID
    */
   // TODO: return multiple events with same production id
+  @ApiOperation({ summary: "Returns the Event with the ID in the URL." })
+  @ApiOkResponse({ type: EventDto, description: "Event Found." })
   @Get(":id")
   async getEventById(@Param("id", ParseIntPipe) id: number): Promise<EventDto> {
     return await this.eventService.getEventById(id);
@@ -44,6 +49,9 @@ export class EventController {
    * @param event The parsed EventDto object.
    * @returns The updated EventDto object.
    */
+  @ApiOperation({ summary: "Replaces an existing Event." })
+  @ApiBody({ type: EventDto })
+  @ApiOkResponse({ type: EventDto, description: "Event replaced." })
   @Put(":id")
   async replaceEvent(
     @Param("id", ParseIntPipe) id: number,
@@ -58,6 +66,9 @@ export class EventController {
    * @param patchData The partial EventDto object that is used to modify.
    * @returns The updated EventDto object.
    */
+  @ApiOperation({ summary: "Modifies an existing Event." })
+  @ApiBody({ type: UpdateEventDto })
+  @ApiOkResponse({ type: EventDto, description: "Event modified." })
   @Patch(":id")
   async modifyEvent(
     @Param("id", ParseIntPipe) id: number,
@@ -71,6 +82,8 @@ export class EventController {
    * @param id ID in the URL of the request.
    * @returns Nothing.
    */
+  @ApiOperation({ summary: "Deletes an Event." })
+  @ApiOkResponse({ description: "Event deleted." })
   @Delete(":id")
   async deleteEvent(@Param("id", ParseIntPipe) id: number): Promise<void> {
     return await this.eventService.deleteEvent(id);
@@ -81,6 +94,9 @@ export class EventController {
    * @param newEvent The new EventDto data we want to add
    * @returns The newly created EventDto.
    */
+  @ApiOperation({ summary: "Creates an Event." })
+  @ApiBody({ type: CreateEventDto })
+  @ApiOkResponse({ type: EventDto, description: "Event created." })
   @Post()
   @UsePipes(new ZodValidationPipe(CreateEventSchema))
   async createEvent(

--- a/backend/src/event/event.service.spec.ts
+++ b/backend/src/event/event.service.spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { EventService } from "./event.service";
 import { EventDatabaseService } from "../database/db.event.service";
-import type { Event, UpdateEvent } from "@repo/common";
+import type { EventDto, UpdateEventDto } from "../dto/dto";
 import { BadRequestException } from "@nestjs/common";
 
 describe("EventService", () => {
   let service: EventService;
   let dbService: EventDatabaseService;
 
-  const mockEvent: Event = {
+  const mockEvent: EventDto = {
     id: 1,
     starttime: "2024-01-15T19:00:00Z",
     endtime: "2024-01-15T21:00:00Z",
@@ -17,7 +17,7 @@ describe("EventService", () => {
     price: 25,
   };
 
-  const mockEvents: Event[] = [mockEvent];
+  const mockEvents: EventDto[] = [mockEvent];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -95,9 +95,9 @@ describe("EventService", () => {
     it("should handle database error when event not found", async () => {
       jest
         .spyOn(dbService, "getEventById")
-        .mockRejectedValueOnce(new Error("No Event exists for provided ID"));
+        .mockRejectedValueOnce(new Error("No EventDto exists for provided ID"));
       await expect(service.getEventById(999)).rejects.toThrow(
-        "No Event exists for provided ID"
+        "No EventDto exists for provided ID"
       );
     });
   });
@@ -121,7 +121,7 @@ describe("EventService", () => {
 
   describe("modifyEvent", () => {
     it("should fetch, merge, update, and return the modified event", async () => {
-      const patchData: UpdateEvent = { hall: "Secondary Hall" };
+      const patchData: UpdateEventDto = { hall: "Secondary Hall" };
       const expectedMergedEvent = { ...mockEvent, ...patchData, id: 1 };
       
       jest.spyOn(dbService, "updateEvent").mockResolvedValueOnce(expectedMergedEvent);
@@ -134,12 +134,12 @@ describe("EventService", () => {
     });
 
     it("should throw an error if the event to modify does not exist", async () => {
-      const patchData: UpdateEvent = { hall: "Secondary Hall" };
+      const patchData: UpdateEventDto = { hall: "Secondary Hall" };
       
       // Service fetches by ID first, so mock that fetch to fail
-      jest.spyOn(dbService, "getEventById").mockRejectedValueOnce(new Error("No Event exists for provided ID"));
+      jest.spyOn(dbService, "getEventById").mockRejectedValueOnce(new Error("No EventDto exists for provided ID"));
     
-      await expect(service.modifyEvent(999, patchData)).rejects.toThrow("No Event exists for provided ID");
+      await expect(service.modifyEvent(999, patchData)).rejects.toThrow("No EventDto exists for provided ID");
       expect(dbService.updateEvent).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
-import type { CreateEvent, Event, UpdateEvent } from "@repo/common";
+import type { CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
 import { EventDatabaseService } from "../database/db.event.service";
 
 @Injectable()
@@ -7,20 +7,20 @@ export class EventService {
   constructor(private readonly eventDBService: EventDatabaseService) {}
 
   /**
-   * Fetches all Event objects from the DBService
-   * @returns All Event objects.
+   * Fetches all EventDto objects from the DBService
+   * @returns All EventDto objects.
    */
-  async getAllEvents(): Promise<Event[]> {
+  async getAllEvents(): Promise<EventDto[]> {
     return await this.eventDBService.getEvents({});
   }
 
   /**
-   * Fetches Event object from the DBService with given ID.
+   * Fetches EventDto object from the DBService with given ID.
    * @param id ID of the event as it was in the URL.
-   * @returns The Event object with corresponding ID
+   * @returns The EventDto object with corresponding ID
    */
   // TODO: return multiple events with same production id
-  async getEventById(id: number): Promise<Event> {
+  async getEventById(id: number): Promise<EventDto> {
     return await this.eventDBService.getEventById(id);
   }
 
@@ -28,13 +28,13 @@ export class EventService {
    * Replaces an event in the Database and returns that event.
    * @param id ID of the event as it was in the URL.
    * @param event The event delivered through the request body.
-   * @returns The updated Event object.
+   * @returns The updated EventDto object.
    */
-  async replaceEvent(id: number, event: Event): Promise<Event> {
+  async replaceEvent(id: number, event: EventDto): Promise<EventDto> {
     if (id !== event.id)
       throw new BadRequestException("ID in the URL must match ID in the body.");
 
-    const updatedEvent: Event = await this.eventDBService.updateEvent(event);
+    const updatedEvent: EventDto = await this.eventDBService.updateEvent(event);
 
     return updatedEvent;
   }
@@ -42,19 +42,19 @@ export class EventService {
   /**
    * Modifies an existing event using the data provided in the request Body.
    * @param id ID of the event as it was in the URL.
-   * @param patchData The partial Event object used to update the data in the DB.
-   * @returns The updated Event object.
+   * @param patchData The partial EventDto object used to update the data in the DB.
+   * @returns The updated EventDto object.
    */
-  async modifyEvent(id: number, patchData: UpdateEvent): Promise<Event> {
-    const existingEvent: Event = await this.eventDBService.getEventById(id);
+  async modifyEvent(id: number, patchData: UpdateEventDto): Promise<EventDto> {
+    const existingEvent: EventDto = await this.eventDBService.getEventById(id);
 
-    const mergedEvent: Event = {
+    const mergedEvent: EventDto = {
       ...existingEvent,
       ...patchData,
       id, // Force ID.
     };
 
-    const updatedEvent: Event =
+    const updatedEvent: EventDto =
       await this.eventDBService.updateEvent(mergedEvent);
 
     return updatedEvent;
@@ -62,7 +62,7 @@ export class EventService {
 
   /**
    * Deletes an event from the database.
-   * @param id ID of the Event we want to delete.
+   * @param id ID of the EventDto we want to delete.
    * @returns Nothing.
    */
   async deleteEvent(id: number): Promise<void> {
@@ -72,11 +72,11 @@ export class EventService {
   }
 
   /**
-   * Creates an Event and adds it to the database
-   * @param newEvent The new Event data we want to add
-   * @returns The newly created Event.
+   * Creates an EventDto and adds it to the database
+   * @param newEvent The new EventDto data we want to add
+   * @returns The newly created EventDto.
    */
-  async createEvent(newEvent: CreateEvent) : Promise<Event> {
+  async createEvent(newEvent: CreateEventDto) : Promise<EventDto> {
     return await this.eventDBService.createEvent(newEvent)
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -8,6 +9,21 @@ async function bootstrap() {
     origin: "http://localhost:3001", // Frontend DEV
     methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
     credentials: true,
+  });
+
+  // Swagger
+  const config = new DocumentBuilder()
+    .setTitle("VierNulVier Archive API")
+    .setDescription("Documentation for the VierNulVier Archive API.")
+    .setVersion("0.1")
+    .build();
+  const documentFactory = () => SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup("docs", app, documentFactory, {
+    customCssUrl: 'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.11.0/swagger-ui.min.css',
+    customJs: [
+      'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.11.0/swagger-ui-bundle.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.11.0/swagger-ui-standalone-preset.js',
+    ],
   });
 
   await app.listen(process.env.PORT ?? 3000);

--- a/backend/src/production/production.controller.spec.ts
+++ b/backend/src/production/production.controller.spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ProductionController } from "./production.controller";
 import { ProductionService } from "./production.service";
-import type { Production, UpdateProduction } from "@repo/common";
+import { ProductionDto, UpdateProductionDto } from "../dto/dto"; 
 import { NotFoundException, BadRequestException } from "@nestjs/common";
 
 describe("ProductionController", () => {
   let controller: ProductionController;
   let service: ProductionService;
 
-  const mockProduction: Production = {
+  const mockProduction: ProductionDto = {
     id: 1,
     titel: "The Great Show",
     ondertitel: "A masterpiece",
@@ -20,7 +20,7 @@ describe("ProductionController", () => {
     blog_text: "Blog content",
   };
 
-  const mockProductions: Production[] = [mockProduction];
+  const mockProductions: ProductionDto[] = [mockProduction];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -88,7 +88,7 @@ describe("ProductionController", () => {
 
     it("should throw a NotFoundException if the production does not exist", async () => {
       // Simulate the service not finding the ID in the database
-      jest.spyOn(service, "getProductionById").mockRejectedValueOnce(new NotFoundException("Production not found"));
+      jest.spyOn(service, "getProductionById").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
     
       // Verify the controller passes the exact same exception up
       await expect(controller.getById(999)).rejects.toThrow(NotFoundException);
@@ -103,7 +103,7 @@ describe("ProductionController", () => {
     });
 
     it("should throw a NotFoundException if trying to replace a non-existent production", async () => {
-      jest.spyOn(service, "replaceProduction").mockRejectedValueOnce(new NotFoundException("Production not found"));
+      jest.spyOn(service, "replaceProduction").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
     
       await expect(controller.replaceProduction(999, mockProduction)).rejects.toThrow(NotFoundException);
     });
@@ -111,7 +111,7 @@ describe("ProductionController", () => {
 
   describe("modifyProduction", () => {
     it("should modify and return the production", async () => {
-      const patchData: UpdateProduction = { titel: "A New Title" };
+      const patchData: UpdateProductionDto = { titel: "A New Title" };
       const patchedProduction = { ...mockProduction, titel: "A New Title" };
       
       jest.spyOn(service, "modifyProduction").mockResolvedValueOnce(patchedProduction);
@@ -122,9 +122,9 @@ describe("ProductionController", () => {
     });
 
     it("should throw a NotFoundException if trying to modify a non-existent production", async () => {
-      const patchData: UpdateProduction = { titel: "A New Title" };
+      const patchData: UpdateProductionDto = { titel: "A New Title" };
       
-      jest.spyOn(service, "modifyProduction").mockRejectedValueOnce(new NotFoundException("Production not found"));
+      jest.spyOn(service, "modifyProduction").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
     
       await expect(controller.modifyProduction(999, patchData)).rejects.toThrow(NotFoundException);
     });
@@ -138,7 +138,7 @@ describe("ProductionController", () => {
     });
 
     it("should throw a NotFoundException if trying to delete a non-existent production", async () => {
-      jest.spyOn(service, "deleteProduction").mockRejectedValueOnce(new NotFoundException("Production not found"));
+      jest.spyOn(service, "deleteProduction").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
     
       await expect(controller.deleteProduction(999)).rejects.toThrow(NotFoundException);
     });

--- a/backend/src/production/production.controller.ts
+++ b/backend/src/production/production.controller.ts
@@ -12,7 +12,7 @@ import {
 import { ProductionService } from "./production.service";
 import { ZodValidationPipe } from "../common/pipes/zod.validation.pipe";
 import { ProductionSchema, UpdateProductionSchema, CreateProductionSchema } from "@repo/common";
-import type { Production, UpdateProduction, CreateProduction } from "@repo/common";
+import type { ProductionDto, UpdateProductionDto, CreateProductionDto } from "../dto/dto";
 
 @Controller("production")
 export class ProductionController {
@@ -20,48 +20,48 @@ export class ProductionController {
 
   /**
    * Responds to GET /productions
-   * @returns All Production objects
+   * @returns All ProductionDto objects
    */
   @Get()
-  async getAllProductions(): Promise<Production[]> {
+  async getAllProductions(): Promise<ProductionDto[]> {
     return await this.productionService.getAllProductions();
   }
 
   /**
    * Responds to GET /productions/:id
    * @param id ID in the URL of the request.
-   * @returns The Production object with corresponding ID
+   * @returns The ProductionDto object with corresponding ID
    */
   @Get(":id")
-  async getById(@Param("id", ParseIntPipe) id: number): Promise<Production> {
+  async getById(@Param("id", ParseIntPipe) id: number): Promise<ProductionDto> {
     return await this.productionService.getProductionById(id);
   }
 
   /**
    * Responds to a PUT to "/production/:id".
    * @param id The ID in the URL.
-   * @param production The parsed Production object.
-   * @returns The newly updated Production.
+   * @param production The parsed ProductionDto object.
+   * @returns The newly updated ProductionDto.
    */
   @Put(":id")
   async replaceProduction(
     @Param("id", ParseIntPipe) id: number,
-    @Body(new ZodValidationPipe(ProductionSchema)) production: Production,
-  ): Promise<Production> {
+    @Body(new ZodValidationPipe(ProductionSchema)) production: ProductionDto,
+  ): Promise<ProductionDto> {
     return await this.productionService.replaceProduction(id, production);
   }
 
   /**
    * Responds to a PATCH to "/production/:id".
    * @param id The ID in the URL.
-   * @param patchData The parsed UpdateProduction object.
-   * @returns The newly updated Production.
+   * @param patchData The parsed UpdateProductionDto object.
+   * @returns The newly updated ProductionDto.
    */
   @Patch(":id")
   async modifyProduction(
     @Param("id", ParseIntPipe) id: number,
-    @Body(new ZodValidationPipe(UpdateProductionSchema)) patchData: UpdateProduction,
-  ): Promise<Production> {
+    @Body(new ZodValidationPipe(UpdateProductionSchema)) patchData: UpdateProductionDto,
+  ): Promise<ProductionDto> {
     return await this.productionService.modifyProduction(id, patchData);
   }
 
@@ -77,14 +77,14 @@ export class ProductionController {
 
   /**
    * Responds to a POST to "/production/".
-   * @param newProduction The new Production data we want to add
-   * @returns The newly created Production.
+   * @param newProduction The new ProductionDto data we want to add
+   * @returns The newly created ProductionDto.
    */
   @Post()
   @UsePipes(new ZodValidationPipe(CreateProductionSchema))
   async createProduction(
-    @Body() newProduction: CreateProduction,
-  ): Promise<Production> {
+    @Body() newProduction: CreateProductionDto,
+  ): Promise<ProductionDto> {
     return this.productionService.createProduction(newProduction);
   }
 }

--- a/backend/src/production/production.controller.ts
+++ b/backend/src/production/production.controller.ts
@@ -12,7 +12,8 @@ import {
 import { ProductionService } from "./production.service";
 import { ZodValidationPipe } from "../common/pipes/zod.validation.pipe";
 import { ProductionSchema, UpdateProductionSchema, CreateProductionSchema } from "@repo/common";
-import type { ProductionDto, UpdateProductionDto, CreateProductionDto } from "../dto/dto";
+import { ProductionDto, UpdateProductionDto, CreateProductionDto } from "../dto/dto";
+import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 
 @Controller("production")
 export class ProductionController {
@@ -22,6 +23,8 @@ export class ProductionController {
    * Responds to GET /productions
    * @returns All ProductionDto objects
    */
+  @ApiOperation({ summary: "Returns all Production objects." })
+  @ApiOkResponse({ type: ProductionDto, isArray: true, description: "All Productions returned." })
   @Get()
   async getAllProductions(): Promise<ProductionDto[]> {
     return await this.productionService.getAllProductions();
@@ -32,6 +35,8 @@ export class ProductionController {
    * @param id ID in the URL of the request.
    * @returns The ProductionDto object with corresponding ID
    */
+  @ApiOperation({ summary: "Returns the Production with id in the URL." })
+  @ApiOkResponse({ type: ProductionDto, description: "Production Found." })
   @Get(":id")
   async getById(@Param("id", ParseIntPipe) id: number): Promise<ProductionDto> {
     return await this.productionService.getProductionById(id);
@@ -43,6 +48,9 @@ export class ProductionController {
    * @param production The parsed ProductionDto object.
    * @returns The newly updated ProductionDto.
    */
+  @ApiOperation({ summary: "Replaces a Production." })
+  @ApiBody({ type: ProductionDto })
+  @ApiOkResponse({ type: ProductionDto, description: "Production Replaced." })
   @Put(":id")
   async replaceProduction(
     @Param("id", ParseIntPipe) id: number,
@@ -57,6 +65,9 @@ export class ProductionController {
    * @param patchData The parsed UpdateProductionDto object.
    * @returns The newly updated ProductionDto.
    */
+  @ApiOperation({ summary: "Modifies an existing Production." })
+  @ApiBody({ type: UpdateProductionDto })
+  @ApiOkResponse({ type: ProductionDto, description: "Production Modified." })
   @Patch(":id")
   async modifyProduction(
     @Param("id", ParseIntPipe) id: number,
@@ -70,6 +81,8 @@ export class ProductionController {
    * @param id The ID in the URL.
    * @returns Nothing.
    */
+  @ApiOperation({ summary: "Deletes a Production." })
+  @ApiOkResponse({ description: "Production Deleted." })
   @Delete(":id")
   async deleteProduction(@Param("id", ParseIntPipe) id: number): Promise<void> {
     return await this.productionService.deleteProduction(id);
@@ -80,6 +93,9 @@ export class ProductionController {
    * @param newProduction The new ProductionDto data we want to add
    * @returns The newly created ProductionDto.
    */
+  @ApiOperation({ summary: "Creates a new Production." })
+  @ApiBody({ type: CreateProductionDto })
+  @ApiOkResponse({ type: ProductionDto, description: "Production Created." })
   @Post()
   @UsePipes(new ZodValidationPipe(CreateProductionSchema))
   async createProduction(

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -1,14 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { ProductionService } from "./production.service";
 import { ProductionDatabaseService } from "../database/db.production.service";
-import type { Production, UpdateProduction } from "@repo/common";
+import type { ProductionDto, UpdateProductionDto } from "../dto/dto";
 import { BadRequestException } from "@nestjs/common";
 
 describe("ProductionService", () => {
   let service: ProductionService;
   let dbService: ProductionDatabaseService;
 
-  const mockProduction: Production = {
+  const mockProduction: ProductionDto = {
     id: 1,
     titel: "The Great Show",
     ondertitel: "A masterpiece",
@@ -20,7 +20,7 @@ describe("ProductionService", () => {
     blog_text: "Blog content",
   };
 
-  const mockProductions: Production[] = [mockProduction];
+  const mockProductions: ProductionDto[] = [mockProduction];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -97,9 +97,9 @@ describe("ProductionService", () => {
     it("should handle database error when production not found", async () => {
       jest
         .spyOn(dbService, "getProductionById")
-        .mockRejectedValueOnce(new Error("No Production exists for provided ID"));
+        .mockRejectedValueOnce(new Error("No ProductionDto exists for provided ID"));
       await expect(service.getProductionById(999)).rejects.toThrow(
-        "No Production exists for provided ID"
+        "No ProductionDto exists for provided ID"
       );
     });
   });
@@ -123,7 +123,7 @@ describe("ProductionService", () => {
 
   describe("modifyProduction", () => {
     it("should fetch, merge, update, and return the modified production", async () => {
-      const patchData: UpdateProduction = { titel: "Patched Title" };
+      const patchData: UpdateProductionDto = { titel: "Patched Title" };
       const expectedMergedProduction = { ...mockProduction, ...patchData, id: 1 };
       
       jest.spyOn(dbService, "updateProduction").mockResolvedValueOnce(expectedMergedProduction);
@@ -136,13 +136,13 @@ describe("ProductionService", () => {
     });
 
     it("should throw an error if the production to modify does not exist", async () => {
-      const patchData: UpdateProduction = { titel: "Patched Title" };
+      const patchData: UpdateProductionDto = { titel: "Patched Title" };
       
       // Simulate the database failing to find the record
-      jest.spyOn(dbService, "getProductionById").mockRejectedValueOnce(new Error("No Production exists for provided ID"));
+      jest.spyOn(dbService, "getProductionById").mockRejectedValueOnce(new Error("No ProductionDto exists for provided ID"));
 
       // The service should halt and bubble up the fetch error, never calling updateProduction
-      await expect(service.modifyProduction(999, patchData)).rejects.toThrow("No Production exists for provided ID");
+      await expect(service.modifyProduction(999, patchData)).rejects.toThrow("No ProductionDto exists for provided ID");
       expect(dbService.updateProduction).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/production/production.service.ts
+++ b/backend/src/production/production.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
-import { CreateProduction, Production, UpdateProduction } from "@repo/common";
+import { CreateProductionDto, ProductionDto, UpdateProductionDto } from "../dto/dto";
 import { ProductionDatabaseService } from "../database/db.production.service";
 
 @Injectable()
@@ -9,69 +9,69 @@ export class ProductionService {
   ) {}
 
   /**
-   * Fetches all Production objects from the DBService
-   * @returns All Production objects
+   * Fetches all ProductionDto objects from the DBService
+   * @returns All ProductionDto objects
    */
-  async getAllProductions(): Promise<Production[]> {
+  async getAllProductions(): Promise<ProductionDto[]> {
     return await this.productionDBService.getProductions({});
   }
 
   /**
-   * Fetches Production object from the DBService with given ID.
+   * Fetches ProductionDto object from the DBService with given ID.
    * @param id ID in the URL of the request.
-   * @returns The Production object with corresponding ID
+   * @returns The ProductionDto object with corresponding ID
    */
-  async getProductionById(id: number): Promise<Production> {
+  async getProductionById(id: number): Promise<ProductionDto> {
     return await this.productionDBService.getProductionById(id);
   }
 
   /**
-   * Replaces a Production in the database and returns the updated one.
+   * Replaces a ProductionDto in the database and returns the updated one.
    * @param id The ID of the production.
-   * @param production The Production Object itself.
-   * @returns The newly updated Production.
+   * @param production The ProductionDto Object itself.
+   * @returns The newly updated ProductionDto.
    */
   async replaceProduction(
     id: number,
-    production: Production,
-  ): Promise<Production> {
+    production: ProductionDto,
+  ): Promise<ProductionDto> {
     if (id !== production.id)
       throw new BadRequestException("ID in the URL must match ID in the body.");
 
-    const updatedProduction: Production =
+    const updatedProduction: ProductionDto =
       await this.productionDBService.updateProduction(id, production);
 
     return updatedProduction;
   }
 
   /**
-   * Modifies an existing Production with the data provided in the body.
+   * Modifies an existing ProductionDto with the data provided in the body.
    * @param id The ID of the production.
    * @param patchData The data we want to update.
-   * @returns The newly updated Production.
+   * @returns The newly updated ProductionDto.
    */
   async modifyProduction(
     id: number,
-    patchData: UpdateProduction,
-  ): Promise<Production> {
-    const existingProduction: Production =
+    patchData: UpdateProductionDto,
+  ): Promise<ProductionDto> {
+    const existingProduction: ProductionDto =
       await this.productionDBService.getProductionById(id);
 
-    const mergedProduction: Production = {
+    const mergedProduction: ProductionDto = {
       ...existingProduction,
       ...patchData,
       id,
     };
 
-    const updatedProduction: Production =
+    const updatedProduction: ProductionDto =
       await this.productionDBService.updateProduction(id, mergedProduction);
 
     return updatedProduction;
   }
 
   /**
-   * Deletes a Production from the database.
-   * @param id The ID of the Production.
+   * Deletes a ProductionDto from the database.
+   * @param id The ID of the ProductionDto.
    * @returns Nothing.
    */
   async deleteProduction(id: number): Promise<void> {
@@ -80,11 +80,11 @@ export class ProductionService {
   }
 
   /**
-   * Creates a Production and adds it to the database
-   * @param newProduction The new Production data we want to add
-   * @returns The newly created Production.
+   * Creates a ProductionDto and adds it to the database
+   * @param newProduction The new ProductionDto data we want to add
+   * @returns The newly created ProductionDto.
    */
-  async createProduction(newProduction: CreateProduction) : Promise<Production> {
+  async createProduction(newProduction: CreateProductionDto) : Promise<ProductionDto> {
     return await this.productionDBService.createProduction(newProduction)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.6",
         "@repo/common": "*",
         "dotenv": "^17.3.1",
         "nestjs-zod": "^5.1.1",
@@ -3038,6 +3039,12 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -3370,6 +3377,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.13",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.13.tgz",
@@ -3487,6 +3514,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.23",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.31.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -6338,6 +6398,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -8656,7 +8723,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -13934,7 +14000,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -18189,6 +18254,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@repo/common": "*",
         "dotenv": "^17.3.1",
+        "nestjs-zod": "^5.1.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -10325,7 +10326,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14883,6 +14883,26 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nestjs-zod": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nestjs-zod/-/nestjs-zod-5.1.1.tgz",
+      "integrity": "sha512-pXa9Jrdip7iedKvGxJTvvCFVRCoIcNENPCsHjpCefPH3PcFejRgkZkUcr3TYITRyxnUk7Zy5OsLpirZGLYBfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/swagger": "^7.4.2 || ^8.0.0 || ^11.0.0",
+        "rxjs": "^7.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/swagger": {
+          "optional": true
+        }
+      }
     },
     "node_modules/nitropack": {
       "version": "2.13.1",


### PR DESCRIPTION
>[!IMPORTANT]
>Gelieve zo snel mogelijk goed te keuren zodat dit gemerged kan worden. Zo kan iedereen die nu nog endpoints aan het schrijven is deze  toevoegen aan de documentatie. Als je niet weet hoe kijk eens naar de functies die al werden gedocument.

## 🎯 MAIN GOAL
- [x] deze PR implementeert een nieuwe feature
* Swagger DTO en implementatie die een extra endpoint toevoegt voor de API docs.

Op deze manier wordt het een stuk gemakkelijker om de API te testen (er moet namelijk geen CURL meer gebruikt worden).

Om dit te bereiken moeten de bestaande schema's in een DTO gewikkeld worden om te werken in de backend. Dit zijn fundamenteel de zelfde types als in `/common`, maar hebben extra info voor Swagger.

## 🛠️ TESTING

* Er moet voor deze specifieke update geen testing gebeuren.

## 📝 DOCUMENTATION

* Niet van toepassing.

## 🔍 HOW TO TEST

* Als je wil zien hoe de docs eruitzien dan kun je gewoon de `backend` starten en browsen naar  `http://localhost:3000`. Dit zal je redirecten naar de docs.

>[!WARNING]
>De Production API werkt op dit moment niet aangezen develop nog niet ge-update is met de nieuwe schemas.

## ✅ CLOSED ISSUES
- #69 