### PR TITLE
implement extra query filters on date before, after and inbetween

### DIFF
--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -41,7 +41,7 @@ export class EventDatabaseService {
   /**
    * Generic get function for events.
    * @param filters gives the freedom to define the filters of the search you want.
-   * All filters are filtered by equals.
+   * All filters are filtered by equals except for date filters (see function).
    * Not all filters need to be defined, only the ones you want to use.
    * i.e: getEvents({p_id: id}) will give a list of all events with the given p_id.
    * @returns All events for the given filters.
@@ -50,6 +50,12 @@ export class EventDatabaseService {
     filters: Partial<{
       genre: string;
       date: string;
+      // Return events where the provided date lies between starttime and endtime
+      date_between: string;
+      // Return events where starttime is before the provided date
+      date_before: string;
+      // Return events where endtime is after the provided date
+      date_after: string;
       hall: string;
       id: number;
       production_id: number;
@@ -71,6 +77,28 @@ export class EventDatabaseService {
     if (filters.date) {
       conditions.push(`DATE(e.starttime) = $${i} OR DATE(e.endtime) = $${i}`);
       values.push(filters.date);
+      i++;
+    }
+
+    // Filter by given date lying between starttime and endtime (inclusive)
+    if (filters.date_between) {
+      // Use explicit timestamp comparison to include time component
+      conditions.push(`$${i}::timestamp BETWEEN e.starttime AND e.endtime`);
+      values.push(filters.date_between);
+      i++;
+    }
+
+    // Filter events whose starttime is before the provided date
+    if (filters.date_before) {
+      conditions.push(`e.starttime < $${i}::timestamp OR e.endtime < $${i}::timestamp`);
+      values.push(filters.date_before);
+      i++;
+    }
+
+    // Filter events whose endtime is after the provided date
+    if (filters.date_after) {
+      conditions.push(`e.endtime > $${i}::timestamp OR e.starttime > $${i}::timestamp`);
+      values.push(filters.date_after);
       i++;
     }
 

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -90,14 +90,14 @@ export class EventDatabaseService {
 
     // Filter events whose starttime is before the provided date
     if (filters.date_before) {
-      conditions.push(`e.starttime < $${i}::timestamp OR e.endtime < $${i}::timestamp`);
+      conditions.push(`e.starttime < $${i}::timestamp`);
       values.push(filters.date_before);
       i++;
     }
 
     // Filter events whose endtime is after the provided date
     if (filters.date_after) {
-      conditions.push(`e.endtime > $${i}::timestamp OR e.starttime > $${i}::timestamp`);
+      conditions.push(`e.endtime > $${i}::timestamp`);
       values.push(filters.date_after);
       i++;
     }

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -111,14 +111,14 @@ export class ProductionDatabaseService {
 
     // Filter events whose starttime is before the provided date
     if (filters.date_before) {
-      conditions.push(`e.starttime < $${i}::timestamp OR e.endtime < $${i}::timestamp`);
+      conditions.push(`e.starttime < $${i}::timestamp`);
       values.push(filters.date_before);
       i++;
     }
 
     // Filter events whose endtime is after the provided date
     if (filters.date_after) {
-      conditions.push(`e.endtime > $${i}::timestamp OR e.starttime > $${i}::timestamp`);
+      conditions.push(`e.endtime > $${i}::timestamp`);
       values.push(filters.date_after);
       i++;
     }

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -56,7 +56,7 @@ export class ProductionDatabaseService {
   /**
    * Generic get function for productions.
    * @param filters gives the freedom to define the filters of the search you want.
-   * All filters are filtered by equals.
+   * All filters are filtered by equals except for date filters (see function).
    * Not all filters need to be defined, only the ones you want to use.
    * i.e: getProductions({genre: genre}) will give a list of all productions with the given genre.
    * @returns All productions for the given filters.
@@ -66,6 +66,12 @@ export class ProductionDatabaseService {
       genre: string;
       hall: string;
       date: string;
+      // Return events where the provided date lies between starttime and endtime
+      date_between: string;
+      // Return events where starttime is before the provided date
+      date_before: string;
+      // Return events where endtime is after the provided date
+      date_after: string;
       titel: string;
       id: number;
     }>,
@@ -92,6 +98,28 @@ export class ProductionDatabaseService {
     if (filters.date) {
       conditions.push(`(DATE(e.starttime) = $${i} OR DATE(e.endtime) = $${i})`);
       values.push(filters.date);
+      i++;
+    }
+
+    // Filter by given date lying between starttime and endtime (inclusive)
+    if (filters.date_between) {
+      // Use explicit timestamp comparison to include time component
+      conditions.push(`$${i}::timestamp BETWEEN e.starttime AND e.endtime`);
+      values.push(filters.date_between);
+      i++;
+    }
+
+    // Filter events whose starttime is before the provided date
+    if (filters.date_before) {
+      conditions.push(`e.starttime < $${i}::timestamp OR e.endtime < $${i}::timestamp`);
+      values.push(filters.date_before);
+      i++;
+    }
+
+    // Filter events whose endtime is after the provided date
+    if (filters.date_after) {
+      conditions.push(`e.endtime > $${i}::timestamp OR e.starttime > $${i}::timestamp`);
+      values.push(filters.date_after);
       i++;
     }
 


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] deze PR implementeert een nieuwe feature
* implementeerd volgende filters in de event en de production search:
  * query for fetching if date is inbetween start and end date
  * query for fetching if date is before start and end date
  * query for fetching if date is after value start and end date
  
- [ ] deze PR fixt één of meerdere bugs
* nvt

## 🛠️ TESTING
Geen testen nodig (denk ik)


## 📝 DOCUMENTATION
- [x] Er is voldoende documentatie geschreven voor deze code

**Nog missende documentatie:**
* Extra uitleg in boven functie over argumenten

## 🔍 HOW TO TEST
Query in de database uittesten.

## ⚠️ REMAINING ISSUES
- [ ] Er bevinden zich nog onopgeloste bugs in de code
* nvt
- [ ] Deze code vereist dat er ergens anders nog iets aangepast wordt (bv. een aangepaste database structuur, API-endpoint, ...)
* nvt
 
## ✅ CLOSED ISSUES
- #19 