### PR TITLE
Feature/linking tags

### DIFF
--- a/backend/database_proper/db.dbml
+++ b/backend/database_proper/db.dbml
@@ -46,7 +46,7 @@ Table tags {
   tag text [not null, unique]
 }
 
-Table production_tags {
+Table production_tag {
   production_id int [not null]
   tag_id int [not null]
 
@@ -63,5 +63,5 @@ Ref: production_blogs.blog_id > blogs.id [delete: cascade]
 Ref: event_blogs.event_id > events.id [delete: cascade]
 Ref: event_blogs.blog_id > blogs.id [delete: cascade]
 
-Ref: production_tags.production_id > productions.id [delete: cascade]
-Ref: production_tags.tag_id > tags.id [delete: cascade]
+Ref: production_tag.production_id > productions.id [delete: cascade]
+Ref: production_tag.tag_id > tags.id [delete: cascade]

--- a/backend/database_proper/db_backup_scripts.sql
+++ b/backend/database_proper/db_backup_scripts.sql
@@ -72,7 +72,7 @@ CREATE TABLE tags
     tag TEXT NOT NULL UNIQUE
 );
 
-CREATE TABLE production_tags
+CREATE TABLE production_tag
 (
     production_id INT NOT NULL,
     tag_id        INT NOT NULL,

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -369,7 +369,7 @@ export class ProductionDatabaseService {
     production_id: number,
   ): Promise<void> {
     const query = `
-      INSERT INTO production_tags (production_id, tag_id)
+      INSERT INTO production_tag (production_id, tag_id)
       VALUES ($1, $2)
       ON CONFLICT DO NOTHING
     `;
@@ -387,9 +387,9 @@ export class ProductionDatabaseService {
     production_id: number,
   ): Promise<void> {
     const query = `
-      DELETE FROM production_tags
-      WHERE production_tags.tag_id = $1
-        AND production_tags.production_id = $2
+      DELETE FROM production_tag
+      WHERE production_tag.tag_id = $1
+        AND production_tag.production_id = $2
     `
 
     await this.db.query(query, [tag_id, production_id]);

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -356,4 +356,42 @@ export class ProductionDatabaseService {
 
     await this.db.query(query, [production_id, blog_id]);
   }
+
+  // -- Tags -- //
+
+  /**
+   * Adds an existing Tag to an existing Production in the Database.
+   * @param tag_id The ID of the Tag.
+   * @param production_id The ID of the Production.
+   */
+  async addTagToProduction(
+    tag_id: number,
+    production_id: number,
+  ): Promise<void> {
+    const query = `
+      INSERT INTO production_tags (production_id, tag_id)
+      VALUES ($1, $2)
+      ON CONFLICT DO NOTHING
+    `;
+
+    await this.db.query(query, [production_id, tag_id]);
+  }
+
+  /**
+   * Removes a previously linked Tag from an existing Production in the Database.
+   * @param tag_id The ID of the Tag.
+   * @param production_id The ID of the Production.
+   */
+  async removeTagFromProduction(
+    tag_id: number,
+    production_id: number,
+  ): Promise<void> {
+    const query = `
+      DELETE FROM production_tags
+      WHERE production_tags.tag_id = $1
+        AND production_tags.production_id = $2
+    `
+
+    await this.db.query(query, [tag_id, production_id]);
+  }
 }

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -18,7 +18,7 @@ import {
   UpdateEventSchema,
 } from "@repo/common";
 import { BlogDto, CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
-import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 @Controller("event")
 export class EventController {
@@ -28,6 +28,7 @@ export class EventController {
    * Responds to GET /events
    * @returns All EventDto objects.
    */
+  @ApiTags("Event")
   @ApiOperation({ summary: "Returns all Event objects." })
   @ApiOkResponse({
     type: EventDto,
@@ -45,6 +46,7 @@ export class EventController {
    * @returns The EventDto object with corresponding ID
    */
   // TODO: return multiple events with same production id
+  @ApiTags("Event")
   @ApiOperation({ summary: "Returns the Event with the ID in the URL." })
   @ApiOkResponse({ type: EventDto, description: "Event Found." })
   @Get(":id")
@@ -58,6 +60,7 @@ export class EventController {
    * @param event The parsed EventDto object.
    * @returns The updated EventDto object.
    */
+  @ApiTags("Event")
   @ApiOperation({ summary: "Replaces an existing Event." })
   @ApiBody({ type: EventDto })
   @ApiOkResponse({ type: EventDto, description: "Event replaced." })
@@ -75,6 +78,7 @@ export class EventController {
    * @param patchData The partial EventDto object that is used to modify.
    * @returns The updated EventDto object.
    */
+  @ApiTags("Event")
   @ApiOperation({ summary: "Modifies an existing Event." })
   @ApiBody({ type: UpdateEventDto })
   @ApiOkResponse({ type: EventDto, description: "Event modified." })
@@ -91,6 +95,7 @@ export class EventController {
    * @param id ID in the URL of the request.
    * @returns Nothing.
    */
+  @ApiTags("Event")
   @ApiOperation({ summary: "Deletes an Event." })
   @ApiOkResponse({ description: "Event deleted." })
   @Delete(":id")
@@ -103,6 +108,7 @@ export class EventController {
    * @param newEvent The new EventDto data we want to add
    * @returns The newly created EventDto.
    */
+  @ApiTags("Event")
   @ApiOperation({ summary: "Creates an Event." })
   @ApiBody({ type: CreateEventDto })
   @ApiOkResponse({ type: EventDto, description: "Event created." })
@@ -119,6 +125,7 @@ export class EventController {
    * @param id The id of the Event.
    * @returns A list of all Blog objects linked to this Event.
    */
+  @ApiTags("Event - Blog")
   @ApiOperation({ summary: "Get Blogs linked to a specific Event." })
   @ApiOkResponse({ type: BlogDto, isArray: true, description: "Returned all linked Blogs." })
   @Get(":id/blog")
@@ -132,6 +139,7 @@ export class EventController {
    * @param blogId ID of the Blog.
    * @returns The newly linked Blog object.
    */
+  @ApiTags("Event - Blog")
   @ApiOperation({ summary: "Link a blog to an existing Event." })
   @ApiOkResponse({ type: BlogDto, description: "Linked Blog to Event." })
   @Put(":id/blog/:id2")
@@ -148,6 +156,7 @@ export class EventController {
    * @param blogId ID of the Blog.
    * @returns The Event we just unlinked the Blog from.
    */
+  @ApiTags("Event - Blog")
   @ApiOperation({ summary: "Unlink a blog from an existing Event." })
   @ApiOkResponse({ type: EventDto, description: "Unlinked Blog from Event." })
   @Delete(":id/blog/:id2")

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -28,7 +28,6 @@ export class EventController {
    * Responds to GET /events
    * @returns All EventDto objects.
    */
-  @ApiTags("Event")
   @ApiOperation({ summary: "Returns all Event objects." })
   @ApiOkResponse({
     type: EventDto,
@@ -46,7 +45,6 @@ export class EventController {
    * @returns The EventDto object with corresponding ID
    */
   // TODO: return multiple events with same production id
-  @ApiTags("Event")
   @ApiOperation({ summary: "Returns the Event with the ID in the URL." })
   @ApiOkResponse({ type: EventDto, description: "Event Found." })
   @Get(":id")
@@ -60,7 +58,6 @@ export class EventController {
    * @param event The parsed EventDto object.
    * @returns The updated EventDto object.
    */
-  @ApiTags("Event")
   @ApiOperation({ summary: "Replaces an existing Event." })
   @ApiBody({ type: EventDto })
   @ApiOkResponse({ type: EventDto, description: "Event replaced." })
@@ -78,7 +75,6 @@ export class EventController {
    * @param patchData The partial EventDto object that is used to modify.
    * @returns The updated EventDto object.
    */
-  @ApiTags("Event")
   @ApiOperation({ summary: "Modifies an existing Event." })
   @ApiBody({ type: UpdateEventDto })
   @ApiOkResponse({ type: EventDto, description: "Event modified." })
@@ -95,7 +91,6 @@ export class EventController {
    * @param id ID in the URL of the request.
    * @returns Nothing.
    */
-  @ApiTags("Event")
   @ApiOperation({ summary: "Deletes an Event." })
   @ApiOkResponse({ description: "Event deleted." })
   @Delete(":id")
@@ -108,7 +103,6 @@ export class EventController {
    * @param newEvent The new EventDto data we want to add
    * @returns The newly created EventDto.
    */
-  @ApiTags("Event")
   @ApiOperation({ summary: "Creates an Event." })
   @ApiBody({ type: CreateEventDto })
   @ApiOkResponse({ type: EventDto, description: "Event created." })
@@ -125,7 +119,6 @@ export class EventController {
    * @param id The id of the Event.
    * @returns A list of all Blog objects linked to this Event.
    */
-  @ApiTags("Event - Blog")
   @ApiOperation({ summary: "Get Blogs linked to a specific Event." })
   @ApiOkResponse({ type: BlogDto, isArray: true, description: "Returned all linked Blogs." })
   @Get(":id/blog")
@@ -139,7 +132,6 @@ export class EventController {
    * @param blogId ID of the Blog.
    * @returns The newly linked Blog object.
    */
-  @ApiTags("Event - Blog")
   @ApiOperation({ summary: "Link a blog to an existing Event." })
   @ApiOkResponse({ type: BlogDto, description: "Linked Blog to Event." })
   @Put(":id/blog/:id2")
@@ -156,7 +148,6 @@ export class EventController {
    * @param blogId ID of the Blog.
    * @returns The Event we just unlinked the Blog from.
    */
-  @ApiTags("Event - Blog")
   @ApiOperation({ summary: "Unlink a blog from an existing Event." })
   @ApiOkResponse({ type: EventDto, description: "Unlinked Blog from Event." })
   @Delete(":id/blog/:id2")

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -18,7 +18,7 @@ import {
   UpdateEventSchema,
 } from "@repo/common";
 import { BlogDto, CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
-import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 
 @Controller("event")
 export class EventController {

--- a/backend/src/production/production.controller.spec.ts
+++ b/backend/src/production/production.controller.spec.ts
@@ -44,11 +44,12 @@ describe("ProductionController", () => {
             replaceProduction: jest.fn().mockResolvedValue(mockProduction),
             modifyProduction: jest.fn().mockResolvedValue(mockProduction),
             deleteProduction: jest.fn().mockResolvedValue(undefined),
-            // New mock methods
             createProduction: jest.fn(),
             getProductionBlogs: jest.fn(),
             linkBlogToProduction: jest.fn(),
             unlinkBlogFromProduction: jest.fn(),
+            addTagToProduction: jest.fn(),
+            removeTagFromProduction: jest.fn(),
           },
         },
       ],
@@ -161,44 +162,6 @@ describe("ProductionController", () => {
     });
   });
 
-
-  describe("getTagsOfProductionByID", () => {
-    it("should return tags for a production", async () => {
-      const result = await controller.getTagsOfProductionByID(1);
-      expect(result).toEqual(mockTags);
-      expect(service.getTagsById).toHaveBeenCalledWith(1);
-    });
-
-    it("should call service.getTagsById with the correct production id", async () => {
-      await controller.getTagsOfProductionByID(1);
-      expect(service.getTagsById).toHaveBeenCalledWith(1);
-      expect(service.getTagsById).toHaveBeenCalledTimes(1);
-    });
-
-    it("should return empty array when production has no tags", async () => {
-      jest.spyOn(service, "getTagsById").mockResolvedValueOnce([]);
-      const result = await controller.getTagsOfProductionByID(1);
-      expect(result).toEqual([]);
-    });
-
-    it("should handle different production ids", async () => {
-      await controller.getTagsOfProductionByID(2);
-      expect(service.getTagsById).toHaveBeenCalledWith(2);
-    });
-
-    it("should throw a NotFoundException if the production does not exist", async () => {
-      jest.spyOn(service, "getTagsById").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
-
-      await expect(controller.getTagsOfProductionByID(999)).rejects.toThrow(NotFoundException);
-    });
-
-    it("should handle database errors when fetching tags fails", async () => {
-      jest.spyOn(service, "getTagsById").mockRejectedValueOnce(new Error("Failed to fetch tags"));
-
-      await expect(controller.getTagsOfProductionByID(1)).rejects.toThrow("Failed to fetch tags");
-    });
-  });
-
   describe("-- Blogs --", () => {
     const mockBlog: BlogDto = {
       id: 1,
@@ -255,6 +218,79 @@ describe("ProductionController", () => {
         jest.spyOn(service, "unlinkBlogFromProduction").mockRejectedValueOnce(new NotFoundException("Link not found"));
 
         await expect(controller.unlinkBlogFromEvent(1, 2)).rejects.toThrow(NotFoundException);
+      });
+    });
+  });
+
+  describe("-- Tags --", () => {
+    describe("getTagsOfProductionByID", () => {
+      it("should return tags for a production", async () => {
+        const result = await controller.getTagsOfProductionByID(1);
+        expect(result).toEqual(mockTags);
+        expect(service.getTagsById).toHaveBeenCalledWith(1);
+      });
+
+      it("should call service.getTagsById with the correct production id", async () => {
+        await controller.getTagsOfProductionByID(1);
+        expect(service.getTagsById).toHaveBeenCalledWith(1);
+        expect(service.getTagsById).toHaveBeenCalledTimes(1);
+      });
+
+      it("should return empty array when production has no tags", async () => {
+        jest.spyOn(service, "getTagsById").mockResolvedValueOnce([]);
+        const result = await controller.getTagsOfProductionByID(1);
+        expect(result).toEqual([]);
+      });
+
+      it("should handle different production ids", async () => {
+        await controller.getTagsOfProductionByID(2);
+        expect(service.getTagsById).toHaveBeenCalledWith(2);
+      });
+
+      it("should throw a NotFoundException if the production does not exist", async () => {
+        jest.spyOn(service, "getTagsById").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
+
+        await expect(controller.getTagsOfProductionByID(999)).rejects.toThrow(NotFoundException);
+      });
+
+      it("should handle database errors when fetching tags fails", async () => {
+        jest.spyOn(service, "getTagsById").mockRejectedValueOnce(new Error("Failed to fetch tags"));
+
+        await expect(controller.getTagsOfProductionByID(1)).rejects.toThrow("Failed to fetch tags");
+      });
+    });
+
+    describe("addTagToProduction", () => {
+      it("should add a tag to a production and return the production", async () => {
+        jest.spyOn(service, "addTagToProduction").mockResolvedValueOnce(mockProduction);
+
+        const result = await controller.addTagToProduction(1, 2);
+
+        expect(service.addTagToProduction).toHaveBeenCalledWith(1, 2);
+        expect(result).toEqual(mockProduction);
+      });
+
+      it("should pass through errors if adding a tag fails (e.g., production not found)", async () => {
+        jest.spyOn(service, "addTagToProduction").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
+
+        await expect(controller.addTagToProduction(999, 2)).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe("removeTagFromProduction", () => {
+      it("should remove a tag from a production and return the production", async () => {
+        jest.spyOn(service, "removeTagFromProduction").mockResolvedValueOnce(mockProduction);
+
+        const result = await controller.removeTagFromProduction(1, 2);
+
+        expect(service.removeTagFromProduction).toHaveBeenCalledWith(1, 2);
+        expect(result).toEqual(mockProduction);
+      });
+
+      it("should pass through errors if removing a tag fails (e.g., production not found)", async () => {
+        jest.spyOn(service, "removeTagFromProduction").mockRejectedValueOnce(new NotFoundException("ProductionDto not found"));
+
+        await expect(controller.removeTagFromProduction(999, 2)).rejects.toThrow(NotFoundException);
       });
     });
   });

--- a/backend/src/production/production.controller.ts
+++ b/backend/src/production/production.controller.ts
@@ -13,7 +13,7 @@ import { ProductionService } from "./production.service";
 import { ZodValidationPipe } from "../common/pipes/zod.validation.pipe";
 import { ProductionSchema, UpdateProductionSchema, CreateProductionSchema } from "@repo/common";
 import { ProductionDto, UpdateProductionDto, CreateProductionDto, TagDto, BlogDto } from "../dto/dto";
-import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 
 @Controller("production")
 export class ProductionController {

--- a/backend/src/production/production.controller.ts
+++ b/backend/src/production/production.controller.ts
@@ -107,7 +107,7 @@ export class ProductionController {
   // -- BLOGS -- //
 
   /**
-   * Responds to a GET to "/:id/blog".
+   * Responds to a GET to "/production/:id/blog".
    * @param id The id of the Production.
    * @returns A list of all Blog objects linked to this Production.
    */
@@ -119,7 +119,7 @@ export class ProductionController {
   }
 
   /**
-   * Responds to a PUT to "/:id/blog/:id2"
+   * Responds to a PUT to "/production/:id/blog/:id2"
    * @param productionId ID of the Production.
    * @param blogId ID of the Blog.
    * @returns The newly linked Blog object.
@@ -135,7 +135,7 @@ export class ProductionController {
   }
 
   /**
-   * Responds to a DELETE to "/:id/blog/:id2"
+   * Responds to a DELETE to "/production/:id/blog/:id2"
    * @param productionId ID of the Production.
    * @param blogId ID of the Blog.
    * @returns The Production we just unlinked the Blog from.
@@ -153,7 +153,7 @@ export class ProductionController {
   // -- Tags -- //
 
   /**
-   * Responds to GET /productions/:id/tags
+   * Responds to GET /production/:id/tag
    * @param id ID in the URL of the request.
    * @returns The list of Tag objects for the Production
    */
@@ -164,7 +164,13 @@ export class ProductionController {
     return await this.productionService.getTagsById(id);
   }
 
-  // TODO: Docs
+  
+  /**
+   * Responds to PUT to "/production/:id/tag/:id2".
+   * @param productionId The ID of the Production.
+   * @param tagId The ID of the Tag.
+   * @returns The altered Production.
+   */
   @ApiOperation({ summary: "Adds a Tag to a Production." })
   @ApiOkResponse({ type: ProductionDto, description: "Successfully added Tag to Production." })
   @Put(":id/tag/:id2")
@@ -175,7 +181,12 @@ export class ProductionController {
     return await this.productionService.addTagToProduction(productionId, tagId);
   }
 
-  // TODO: Docs
+  /**
+   * Responds to a DELETE to "/production/:id/tag/:id2".
+   * @param productionId The ID of the Production.
+   * @param tagId The ID of the Tag.
+   * @returns The altered Production.
+   */
   @ApiOperation({ summary: "Removes a Tag from a Production." })
   @ApiOkResponse({ type: ProductionDto, description: "Successfully removed Tag from Production." })
   @Delete(":id/tag/:id2")

--- a/backend/src/production/production.controller.ts
+++ b/backend/src/production/production.controller.ts
@@ -23,7 +23,6 @@ export class ProductionController {
    * Responds to GET /productions
    * @returns All ProductionDto objects
    */
-  @ApiTags("Production")
   @ApiOperation({ summary: "Returns all Production objects." })
   @ApiOkResponse({ type: ProductionDto, isArray: true, description: "All Productions returned." })
   @Get()
@@ -36,7 +35,6 @@ export class ProductionController {
    * @param id ID in the URL of the request.
    * @returns The ProductionDto object with corresponding ID
    */
-  @ApiTags("Production")
   @ApiOperation({ summary: "Returns the Production with id in the URL." })
   @ApiOkResponse({ type: ProductionDto, description: "Production Found." })
   @Get(":id")
@@ -50,7 +48,6 @@ export class ProductionController {
    * @param production The parsed ProductionDto object.
    * @returns The newly updated ProductionDto.
    */
-  @ApiTags("Production")
   @ApiOperation({ summary: "Replaces a Production." })
   @ApiBody({ type: ProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production Replaced." })
@@ -68,7 +65,6 @@ export class ProductionController {
    * @param patchData The parsed UpdateProductionDto object.
    * @returns The newly updated ProductionDto.
    */
-  @ApiTags("Production")
   @ApiOperation({ summary: "Modifies an existing Production." })
   @ApiBody({ type: UpdateProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production Modified." })
@@ -85,7 +81,6 @@ export class ProductionController {
    * @param id The ID in the URL.
    * @returns Nothing.
    */
-  @ApiTags("Production")
   @ApiOperation({ summary: "Deletes a Production." })
   @ApiOkResponse({ description: "Production Deleted." })
   @Delete(":id")
@@ -98,7 +93,6 @@ export class ProductionController {
    * @param newProduction The new ProductionDto data we want to add
    * @returns The newly created ProductionDto.
    */
-  @ApiTags("Production")
   @ApiOperation({ summary: "Creates a new Production." })
   @ApiBody({ type: CreateProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production Created." })
@@ -117,7 +111,6 @@ export class ProductionController {
    * @param id The id of the Production.
    * @returns A list of all Blog objects linked to this Production.
    */
-  @ApiTags("Production - Blog")
   @ApiOperation({ summary: "Get all Blogs linked to a Production." })
   @ApiOkResponse({ type: BlogDto, isArray: true, description: "Returned all Linked blogs." })
   @Get(":id/blog")
@@ -131,7 +124,6 @@ export class ProductionController {
    * @param blogId ID of the Blog.
    * @returns The newly linked Blog object.
    */
-  @ApiTags("Production - Blog")
   @ApiOperation({ summary: "Link a Blog to an existing Production." })
   @ApiOkResponse({ type: BlogDto, description: "Linked Blog to Production." })
   @Put(":id/blog/:id2")
@@ -148,7 +140,6 @@ export class ProductionController {
    * @param blogId ID of the Blog.
    * @returns The Production we just unlinked the Blog from.
    */
-  @ApiTags("Production - Blog")
   @ApiOperation({ summary: "Unlink a Blog from an existing Production." })
   @ApiOkResponse({ type: ProductionDto, description: "Unlinked Blog from Production." })
   @Delete(":id/blog/:id2")
@@ -166,7 +157,6 @@ export class ProductionController {
    * @param id ID in the URL of the request.
    * @returns The list of Tag objects for the Production
    */
-  @ApiTags("Production - Tag")
   @ApiOperation({ summary: "Returns the Tags of the Production with id in the URL." })
   @ApiOkResponse({ type: TagDto, isArray: true, description: "Tags Found." })
   @Get(":id/tag")
@@ -175,7 +165,6 @@ export class ProductionController {
   }
 
   // TODO: Docs
-  @ApiTags("Production - Tag")
   @ApiOperation({ summary: "Adds a Tag to a Production." })
   @ApiOkResponse({ type: ProductionDto, description: "Successfully added Tag to Production." })
   @Put(":id/tag/:id2")
@@ -187,7 +176,6 @@ export class ProductionController {
   }
 
   // TODO: Docs
-  @ApiTags("Production - Tag")
   @ApiOperation({ summary: "Removes a Tag from a Production." })
   @ApiOkResponse({ type: ProductionDto, description: "Successfully removed Tag from Production." })
   @Delete(":id/tag/:id2")

--- a/backend/src/production/production.controller.ts
+++ b/backend/src/production/production.controller.ts
@@ -13,7 +13,7 @@ import { ProductionService } from "./production.service";
 import { ZodValidationPipe } from "../common/pipes/zod.validation.pipe";
 import { ProductionSchema, UpdateProductionSchema, CreateProductionSchema } from "@repo/common";
 import { ProductionDto, UpdateProductionDto, CreateProductionDto, TagDto, BlogDto } from "../dto/dto";
-import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 @Controller("production")
 export class ProductionController {
@@ -23,6 +23,7 @@ export class ProductionController {
    * Responds to GET /productions
    * @returns All ProductionDto objects
    */
+  @ApiTags("Production")
   @ApiOperation({ summary: "Returns all Production objects." })
   @ApiOkResponse({ type: ProductionDto, isArray: true, description: "All Productions returned." })
   @Get()
@@ -35,6 +36,7 @@ export class ProductionController {
    * @param id ID in the URL of the request.
    * @returns The ProductionDto object with corresponding ID
    */
+  @ApiTags("Production")
   @ApiOperation({ summary: "Returns the Production with id in the URL." })
   @ApiOkResponse({ type: ProductionDto, description: "Production Found." })
   @Get(":id")
@@ -43,23 +45,12 @@ export class ProductionController {
   }
 
   /**
-   * Responds to GET /productions/:id/tags
-   * @param id ID in the URL of the request.
-   * @returns The list of Tag objects for the Production
-   */
-  @ApiOperation({ summary: "Returns the Tags of the Production with id in the URL." })
-  @ApiOkResponse({ type: TagDto, isArray: true, description: "Tags Found." })
-  @Get(":id/tags")
-  async getTagsOfProductionByID(@Param("id", ParseIntPipe) id: number): Promise<TagDto[]> {
-    return await this.productionService.getTagsById(id);
-  }
-
-  /**
    * Responds to a PUT to "/production/:id".
    * @param id The ID in the URL.
    * @param production The parsed ProductionDto object.
    * @returns The newly updated ProductionDto.
    */
+  @ApiTags("Production")
   @ApiOperation({ summary: "Replaces a Production." })
   @ApiBody({ type: ProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production Replaced." })
@@ -77,6 +68,7 @@ export class ProductionController {
    * @param patchData The parsed UpdateProductionDto object.
    * @returns The newly updated ProductionDto.
    */
+  @ApiTags("Production")
   @ApiOperation({ summary: "Modifies an existing Production." })
   @ApiBody({ type: UpdateProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production Modified." })
@@ -93,6 +85,7 @@ export class ProductionController {
    * @param id The ID in the URL.
    * @returns Nothing.
    */
+  @ApiTags("Production")
   @ApiOperation({ summary: "Deletes a Production." })
   @ApiOkResponse({ description: "Production Deleted." })
   @Delete(":id")
@@ -105,6 +98,7 @@ export class ProductionController {
    * @param newProduction The new ProductionDto data we want to add
    * @returns The newly created ProductionDto.
    */
+  @ApiTags("Production")
   @ApiOperation({ summary: "Creates a new Production." })
   @ApiBody({ type: CreateProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production Created." })
@@ -123,6 +117,7 @@ export class ProductionController {
    * @param id The id of the Production.
    * @returns A list of all Blog objects linked to this Production.
    */
+  @ApiTags("Production - Blog")
   @ApiOperation({ summary: "Get all Blogs linked to a Production." })
   @ApiOkResponse({ type: BlogDto, isArray: true, description: "Returned all Linked blogs." })
   @Get(":id/blog")
@@ -136,6 +131,7 @@ export class ProductionController {
    * @param blogId ID of the Blog.
    * @returns The newly linked Blog object.
    */
+  @ApiTags("Production - Blog")
   @ApiOperation({ summary: "Link a Blog to an existing Production." })
   @ApiOkResponse({ type: BlogDto, description: "Linked Blog to Production." })
   @Put(":id/blog/:id2")
@@ -152,6 +148,7 @@ export class ProductionController {
    * @param blogId ID of the Blog.
    * @returns The Production we just unlinked the Blog from.
    */
+  @ApiTags("Production - Blog")
   @ApiOperation({ summary: "Unlink a Blog from an existing Production." })
   @ApiOkResponse({ type: ProductionDto, description: "Unlinked Blog from Production." })
   @Delete(":id/blog/:id2")
@@ -160,5 +157,44 @@ export class ProductionController {
     @Param("id2", ParseIntPipe) blogId: number
   ): Promise<ProductionDto> {
     return await this.productionService.unlinkBlogFromProduction(productionId, blogId);
+  }
+
+  // -- Tags -- //
+
+  /**
+   * Responds to GET /productions/:id/tags
+   * @param id ID in the URL of the request.
+   * @returns The list of Tag objects for the Production
+   */
+  @ApiTags("Production - Tag")
+  @ApiOperation({ summary: "Returns the Tags of the Production with id in the URL." })
+  @ApiOkResponse({ type: TagDto, isArray: true, description: "Tags Found." })
+  @Get(":id/tag")
+  async getTagsOfProductionByID(@Param("id", ParseIntPipe) id: number): Promise<TagDto[]> {
+    return await this.productionService.getTagsById(id);
+  }
+
+  // TODO: Docs
+  @ApiTags("Production - Tag")
+  @ApiOperation({ summary: "Adds a Tag to a Production." })
+  @ApiOkResponse({ type: ProductionDto, description: "Successfully added Tag to Production." })
+  @Put(":id/tag/:id2")
+  async addTagToProduction(
+    @Param("id", ParseIntPipe) productionId: number,
+    @Param("id2", ParseIntPipe) tagId: number,
+  ): Promise<ProductionDto> {
+    return await this.productionService.addTagToProduction(productionId, tagId);
+  }
+
+  // TODO: Docs
+  @ApiTags("Production - Tag")
+  @ApiOperation({ summary: "Removes a Tag from a Production." })
+  @ApiOkResponse({ type: ProductionDto, description: "Successfully removed Tag from Production." })
+  @Delete(":id/tag/:id2")
+  async removeTagFromProduction(
+    @Param("id", ParseIntPipe) productionId: number,
+    @Param("id2", ParseIntPipe) tagId: number,
+  ): Promise<ProductionDto> {
+    return await this.productionService.removeTagFromProduction(productionId, tagId);
   }
 }

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -45,11 +45,13 @@ describe("ProductionService", () => {
             getTagsOfProduction: jest.fn().mockResolvedValue(mockTags),
             updateProduction: jest.fn().mockResolvedValue(mockProduction),
             deleteProduction: jest.fn().mockResolvedValue(undefined),
-            // New mock methods
             createProduction: jest.fn(),
             getBlogsOfProduction: jest.fn(),
             linkBlogWithProductionID: jest.fn(),
             deleteBlogFromProduction: jest.fn(),
+            // New mock methods
+            addTagToProduction: jest.fn(),
+            removeTagFromProduction: jest.fn(),
           },
         },
         {
@@ -186,54 +188,6 @@ describe("ProductionService", () => {
     });
   });
 
-  describe("getTagsById", () => {
-    it("should fetch production and return its tags", async () => {
-      const result = await service.getTagsById(1);
-      expect(result).toEqual(mockTags);
-      expect(dbService.getProductionById).toHaveBeenCalledWith(1);
-      expect(dbService.getTagsOfProduction).toHaveBeenCalledWith(mockProduction);
-    });
-
-    it("should call getProductionById with the correct id", async () => {
-      await service.getTagsById(1);
-      expect(dbService.getProductionById).toHaveBeenCalledWith(1);
-      expect(dbService.getProductionById).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call getTagsOfProduction with the fetched production", async () => {
-      await service.getTagsById(1);
-      expect(dbService.getTagsOfProduction).toHaveBeenCalledWith(mockProduction);
-      expect(dbService.getTagsOfProduction).toHaveBeenCalledTimes(1);
-    });
-
-    it("should return empty array when production has no tags", async () => {
-      jest.spyOn(dbService, "getTagsOfProduction").mockResolvedValueOnce([]);
-      const result = await service.getTagsById(1);
-      expect(result).toEqual([]);
-      expect(dbService.getProductionById).toHaveBeenCalledWith(1);
-    });
-
-    it("should handle database error when production is not found", async () => {
-      jest
-        .spyOn(dbService, "getProductionById")
-        .mockRejectedValueOnce(new Error("No ProductionDto exists for provided ID"));
-
-      await expect(service.getTagsById(999)).rejects.toThrow(
-        "No ProductionDto exists for provided ID"
-      );
-      expect(dbService.getTagsOfProduction).not.toHaveBeenCalled();
-    });
-
-    it("should handle database error when fetching tags fails", async () => {
-      jest
-        .spyOn(dbService, "getTagsOfProduction")
-        .mockRejectedValueOnce(new Error("Failed to fetch tags"));
-
-      await expect(service.getTagsById(1)).rejects.toThrow("Failed to fetch tags");
-      expect(dbService.getProductionById).toHaveBeenCalledWith(1);
-    });
-  });
-
   describe("-- Blogs --", () => {
     const mockBlog: BlogDto = {
       id: 1,
@@ -301,6 +255,96 @@ describe("ProductionService", () => {
     });
   });
 
+  describe("-- Tags --", () => {
+    describe("getTagsById", () => {
+      it("should fetch production and return its tags", async () => {
+        const result = await service.getTagsById(1);
+        expect(result).toEqual(mockTags);
+        expect(dbService.getProductionById).toHaveBeenCalledWith(1);
+        expect(dbService.getTagsOfProduction).toHaveBeenCalledWith(mockProduction);
+      });
+
+      it("should call getProductionById with the correct id", async () => {
+        await service.getTagsById(1);
+        expect(dbService.getProductionById).toHaveBeenCalledWith(1);
+        expect(dbService.getProductionById).toHaveBeenCalledTimes(1);
+      });
+
+      it("should call getTagsOfProduction with the fetched production", async () => {
+        await service.getTagsById(1);
+        expect(dbService.getTagsOfProduction).toHaveBeenCalledWith(mockProduction);
+        expect(dbService.getTagsOfProduction).toHaveBeenCalledTimes(1);
+      });
+
+      it("should return empty array when production has no tags", async () => {
+        jest.spyOn(dbService, "getTagsOfProduction").mockResolvedValueOnce([]);
+        const result = await service.getTagsById(1);
+        expect(result).toEqual([]);
+        expect(dbService.getProductionById).toHaveBeenCalledWith(1);
+      });
+
+      it("should handle database error when production is not found", async () => {
+        jest
+          .spyOn(dbService, "getProductionById")
+          .mockRejectedValueOnce(new Error("No ProductionDto exists for provided ID"));
+
+        await expect(service.getTagsById(999)).rejects.toThrow(
+          "No ProductionDto exists for provided ID"
+        );
+        expect(dbService.getTagsOfProduction).not.toHaveBeenCalled();
+      });
+
+      it("should handle database error when fetching tags fails", async () => {
+        jest
+          .spyOn(dbService, "getTagsOfProduction")
+          .mockRejectedValueOnce(new Error("Failed to fetch tags"));
+
+        await expect(service.getTagsById(1)).rejects.toThrow("Failed to fetch tags");
+        expect(dbService.getProductionById).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe("addTagToProduction", () => {
+      it("should silently attempt to add a tag and return the production object", async () => {
+        jest.spyOn(dbService, "addTagToProduction").mockResolvedValueOnce(undefined);
+        jest.spyOn(dbService, "getProductionById").mockResolvedValueOnce(mockProduction);
+
+        const result = await service.addTagToProduction(1, 2);
+
+        expect(dbService.addTagToProduction).toHaveBeenCalledWith(2, 1); // tagId, productionId
+        expect(dbService.getProductionById).toHaveBeenCalledWith(1);
+        expect(result).toEqual(mockProduction);
+      });
+
+      it("should handle failure when fetching the production to return fails", async () => {
+        jest.spyOn(dbService, "addTagToProduction").mockResolvedValueOnce(undefined);
+        jest.spyOn(dbService, "getProductionById").mockRejectedValueOnce(new Error("No ProductionDto exists for provided ID"));
+
+        await expect(service.addTagToProduction(999, 2)).rejects.toThrow("No ProductionDto exists for provided ID");
+      });
+    });
+
+    describe("removeTagFromProduction", () => {
+      it("should silently attempt to remove a tag and return the production object", async () => {
+        jest.spyOn(dbService, "removeTagFromProduction").mockResolvedValueOnce(undefined);
+        jest.spyOn(dbService, "getProductionById").mockResolvedValueOnce(mockProduction);
+
+        const result = await service.removeTagFromProduction(1, 2);
+
+        expect(dbService.removeTagFromProduction).toHaveBeenCalledWith(2, 1); // tagId, productionId
+        expect(dbService.getProductionById).toHaveBeenCalledWith(1);
+        expect(result).toEqual(mockProduction);
+      });
+
+      it("should handle failure when fetching the production to return fails", async () => {
+        jest.spyOn(dbService, "removeTagFromProduction").mockResolvedValueOnce(undefined);
+        jest.spyOn(dbService, "getProductionById").mockRejectedValueOnce(new Error("No ProductionDto exists for provided ID"));
+
+        await expect(service.removeTagFromProduction(999, 2)).rejects.toThrow("No ProductionDto exists for provided ID");
+      });
+    });
+  });
+
   describe("createProduction", () => {
     it("should create a production successfully", async () => {
       const newProduction: CreateProductionDto = {
@@ -343,5 +387,4 @@ describe("ProductionService", () => {
       );
     });
   });
-
 });

--- a/backend/src/production/production.service.ts
+++ b/backend/src/production/production.service.ts
@@ -137,13 +137,24 @@ export class ProductionService {
     return await this.productionDBService.getTagsOfProduction(production);
   }
 
-  // TODO: Docs
+  /**
+   * Adds a specific Tag to a Production.
+   * @param productionId The ID of the Production we want to link the Tag to.
+   * @param tagId The ID of the Tag we want to link.
+   * @returns The Production in question.
+   */
   async addTagToProduction(productionId: number, tagId: number): Promise<ProductionDto> {
     await this.productionDBService.addTagToProduction(tagId, productionId);
     return await this.productionDBService.getProductionById(productionId);
   }
 
-  // TODO: Docs
+  /**
+   * Removes a specific Tag from a Production. If the Tag wasn't linked to the
+   * Production nothing happens.
+   * @param productionId The ID of the Production we want to remove the Tag from.
+   * @param tagId The ID of the Tag we want to remove.
+   * @returns The Production in question.
+   */
   async removeTagFromProduction(productionId: number, tagId: number): Promise<ProductionDto> {
     await this.productionDBService.removeTagFromProduction(tagId, productionId);
     return await this.productionDBService.getProductionById(productionId);

--- a/backend/src/production/production.service.ts
+++ b/backend/src/production/production.service.ts
@@ -34,16 +34,6 @@ export class ProductionService {
   }
 
   /**
-   * Fetches all TagDto objects for a given production id.
-   * @param id ID in the URL of the request.
-   * @returns The list of TagDto objects for the Production
-   */
-  async getTagsById(id: number): Promise<TagDto[]> {
-    const production: ProductionDto = await this.productionDBService.getProductionById(id);
-    return await this.productionDBService.getTagsOfProduction(production);
-  }
-
-  /**
    * Replaces a ProductionDto in the database and returns the updated one.
    * @param id The ID of the production.
    * @param production The ProductionDto Object itself.
@@ -134,4 +124,28 @@ export class ProductionService {
     await this.productionDBService.deleteBlogFromProduction(productionId, blogId);
     return await this.productionDBService.getProductionById(productionId);
   } 
+
+  // -- Tags -- //
+
+  /**
+   * Fetches all TagDto objects for a given production id.
+   * @param id ID in the URL of the request.
+   * @returns The list of TagDto objects for the Production
+   */
+  async getTagsById(id: number): Promise<TagDto[]> {
+    const production: ProductionDto = await this.productionDBService.getProductionById(id);
+    return await this.productionDBService.getTagsOfProduction(production);
+  }
+
+  // TODO: Docs
+  async addTagToProduction(productionId: number, tagId: number): Promise<ProductionDto> {
+    await this.productionDBService.addTagToProduction(tagId, productionId);
+    return await this.productionDBService.getProductionById(productionId);
+  }
+
+  // TODO: Docs
+  async removeTagFromProduction(productionId: number, tagId: number): Promise<ProductionDto> {
+    await this.productionDBService.removeTagFromProduction(tagId, productionId);
+    return await this.productionDBService.getProductionById(productionId);
+  }
 }

--- a/backend/src/tag/tag.controller.ts
+++ b/backend/src/tag/tag.controller.ts
@@ -3,7 +3,6 @@ import { TagService } from './tag.service';
 import { CreateTagDto, UpdateTagDto, TagDto } from '../dto/dto';
 import { ApiOperation, ApiBody, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 
-@ApiTags('tag')
 @Controller('tag')
 export class TagController {
   constructor(private readonly tagService: TagService) {}

--- a/backend/src/tag/tag.controller.ts
+++ b/backend/src/tag/tag.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Post, Body, Patch, Param, Delete, ParseIntPipe } from '@nestjs/common';
 import { TagService } from './tag.service';
 import { CreateTagDto, UpdateTagDto, TagDto } from '../dto/dto';
-import { ApiOperation, ApiBody, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 
 @Controller('tag')
 export class TagController {


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] deze PR implementeert een nieuwe feature

* Er werd de mogelijkheid toegevoegd om via de API een Tag te linken aan een Production.
* Om dit te ondersteunen werden extrra querys toegevoegd aan de Production DB Service en werd het databankschema aangepast (omdat daar `production_tags` stond en in de DB was het `production_tag`).

## 🛠️ TESTING
- [x] Er zijn voldoende testen geschreven voor deze code

## 📝 DOCUMENTATION
- [x] Er is voldoende documentatie geschreven voor deze code

## 🔍 HOW TO TEST

Ga in de Swagger docs en test de nieuwe endpoints `/production/:id/tag/:id2` uit voor PUT en DELETE. Check of de links effectief aangemaakt en verwijderd worden.

## ⚠️ REMAINING ISSUES

Alles is gefixt.

## ✅ CLOSED ISSUES

- #85 
