### PR TITLE
Remove Blog functionality from Event

### DIFF
--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { DbService } from "./db.service";
-import { BlogDto, CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
+import { CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
 
 @Injectable()
 export class EventDatabaseService {
@@ -20,22 +20,6 @@ export class EventDatabaseService {
       );
 
     return events[0]; // There should be an EventDto in here if the length is not 0.
-  }
-
-  /**
-   * Get all blogs listed under a given event.
-   * @param id the id of an event you want the blogs of.
-   * @returns a list of blogs connected to the given event.
-   */
-  async getBlogsOfEvent(id: number): Promise<BlogDto[]> {
-    const query = `
-    SELECT b.*
-    FROM blogs b
-    JOIN event_blogs eb ON b.id = eb.blog_id
-    WHERE eb.event_id = $1
-  `;
-
-    return await this.db.query(query, [id]);
   }
 
   /**
@@ -263,59 +247,5 @@ export class EventDatabaseService {
     const query = `DELETE FROM events WHERE production_id = $1`;
 
     await this.db.query(query, [production_id]);
-  }
-
-  /**
-   * Delete function for deleting blogs from the database.
-   * This function deletes all blogs associated with a given event_id
-   * @param event_id must be a valid id in the database. If an invalid id is given, then nothing happens and no errors are thrown.
-   * (silent handling)
-   * @returns nothing.
-   */
-  async deleteBlogsWithEventID(event_id: number): Promise<void> {
-    const query = `
-      DELETE FROM blogs
-        USING event_blogs
-      WHERE blogs.id = event_blogs.blog_id
-        AND event_blogs.event_id = $1
-    `;
-
-    await this.db.query(query, [event_id]);
-  }
-
-  /**
-   * Delete function for deleting blogs from the database.
-   * This function deletes a single blog-LINK associated with a given event_id
-   * note: it does not delete the blog itself only from being linked to the given event.
-   * @param event_id must be a valid id in the database. If an invalid id is given, then nothing happens and no errors are thrown.
-   * @param blog_id must be a valid id in the database. If an invalid id is given, then nothing happens and no errors are thrown.
-   * (silent handling)
-   * @returns nothing.
-   */
-  async deleteBlogFromEvent(event_id: number, blog_id: number): Promise<void> {
-    const query = `
-      DELETE FROM event_blogs
-      WHERE event_blogs.blog_id = $1
-        AND event_blogs.event_id = $2
-    `;
-
-    await this.db.query(query, [blog_id, event_id]);
-  }
-
-  /**
-   * Link an existing blog to an event.
-   * @param blog_id must be a valid id in the database. If an invalid id is given, then nothing happens and no errors are thrown.
-   * @param event_id must be a valid id in the database. If an invalid id is given, then nothing happens and no errors are thrown.
-   * (silent handling)
-   * @returns nothing.
-   */
-  async linkBlogWithEventID(blog_id: number, event_id: number): Promise<void> {
-    const query = `
-      INSERT INTO event_blogs (event_id, blog_id)
-      VALUES ($1, $2)
-      ON CONFLICT DO NOTHING
-    `;
-
-    await this.db.query(query, [event_id, blog_id]);
   }
 }

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -1,6 +1,12 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
 import { DbService } from "./db.service";
-import { BlogDto, CreateProductionDto, ProductionDto, TagDto, UpdateProductionDto, } from "../dto/dto";
+import {
+  BlogDto,
+  CreateProductionDto,
+  ProductionDto,
+  TagDto,
+  UpdateProductionDto,
+} from "../dto/dto";
 
 @Injectable()
 export class ProductionDatabaseService {

--- a/backend/src/event/event.controller.spec.ts
+++ b/backend/src/event/event.controller.spec.ts
@@ -32,9 +32,6 @@ describe("EventController", () => {
             modifyEvent: jest.fn().mockResolvedValue(mockEvent),
             deleteEvent: jest.fn().mockResolvedValue(undefined),
             createEvent: jest.fn(),
-            getEventBlogs: jest.fn(),
-            linkBlogToEvent: jest.fn(),
-            unlinkBlogFromEvent: jest.fn(),
           },
         },
       ],
@@ -153,53 +150,6 @@ describe("EventController", () => {
       await expect(controller.deleteEvent(999)).rejects.toThrow(
         NotFoundException,
       );
-    });
-  });
-
-  // ... existing tests ...
-
-  describe("-- Blogs --", () => {
-    const mockBlog = {
-      id: 1,
-      title: "Event Update",
-      content: "This is a blog about the event.",
-    };
-
-    describe("getEventBlogs", () => {
-      it("should return an array of blogs linked to the event", async () => {
-        const expectedBlogs = [mockBlog];
-        service.getEventBlogs = jest.fn().mockResolvedValue(expectedBlogs);
-
-        const result = await controller.getEventBlogs(1);
-
-        expect(result).toEqual(expectedBlogs);
-        expect(service.getEventBlogs).toHaveBeenCalledWith(1);
-        expect(service.getEventBlogs).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe("linkBlogToEvent", () => {
-      it("should link a blog to an event and return the blog", async () => {
-        service.linkBlogToEvent = jest.fn().mockResolvedValue(mockBlog);
-
-        const result = await controller.linkBlogToEvent(1, 2);
-
-        expect(result).toEqual(mockBlog);
-        expect(service.linkBlogToEvent).toHaveBeenCalledWith(1, 2);
-        expect(service.linkBlogToEvent).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe("unlinkBlogFromEvent", () => {
-      it("should unlink a blog from an event and return the unlinked event", async () => {
-        service.unlinkBlogFromEvent = jest.fn().mockResolvedValue(mockEvent);
-
-        const result = await controller.unlinkBlogFromEvent(1, 2);
-
-        expect(result).toEqual(mockEvent);
-        expect(service.unlinkBlogFromEvent).toHaveBeenCalledWith(1, 2);
-        expect(service.unlinkBlogFromEvent).toHaveBeenCalledTimes(1);
-      });
     });
   });
 

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -17,7 +17,7 @@ import {
   EventSchema,
   UpdateEventSchema,
 } from "@repo/common";
-import { BlogDto, CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
+import { CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
 import { ApiBody, ApiOkResponse, ApiOperation } from "@nestjs/swagger";
 
 @Controller("event")
@@ -110,57 +110,5 @@ export class EventController {
   @UsePipes(new ZodValidationPipe(CreateEventSchema))
   async createEvent(@Body() newEvent: CreateEventDto): Promise<EventDto> {
     return this.eventService.createEvent(newEvent);
-  }
-
-  // -- BLOGS -- //
-
-  /**
-   * Responds to a GET to "/:id/blog".
-   * @param id The id of the Event.
-   * @returns A list of all Blog objects linked to this Event.
-   */
-  @ApiOperation({ summary: "Get Blogs linked to a specific Event." })
-  @ApiOkResponse({
-    type: BlogDto,
-    isArray: true,
-    description: "Returned all linked Blogs.",
-  })
-  @Get(":id/blog")
-  async getEventBlogs(
-    @Param("id", ParseIntPipe) id: number,
-  ): Promise<BlogDto[]> {
-    return await this.eventService.getEventBlogs(id);
-  }
-
-  /**
-   * Responds to a PUT to "/:id/blog/:id2"
-   * @param eventId ID of the Event.
-   * @param blogId ID of the Blog.
-   * @returns The newly linked Blog object.
-   */
-  @ApiOperation({ summary: "Link a blog to an existing Event." })
-  @ApiOkResponse({ type: BlogDto, description: "Linked Blog to Event." })
-  @Put(":id/blog/:id2")
-  async linkBlogToEvent(
-    @Param("id", ParseIntPipe) eventId: number,
-    @Param("id2", ParseIntPipe) blogId: number,
-  ): Promise<BlogDto> {
-    return await this.eventService.linkBlogToEvent(eventId, blogId);
-  }
-
-  /**
-   * Responds to a DELETE to "/:id/blog/:id2"
-   * @param eventId ID of the Event.
-   * @param blogId ID of the Blog.
-   * @returns The Event we just unlinked the Blog from.
-   */
-  @ApiOperation({ summary: "Unlink a blog from an existing Event." })
-  @ApiOkResponse({ type: EventDto, description: "Unlinked Blog from Event." })
-  @Delete(":id/blog/:id2")
-  async unlinkBlogFromEvent(
-    @Param("id", ParseIntPipe) eventId: number,
-    @Param("id2", ParseIntPipe) blogId: number,
-  ): Promise<EventDto> {
-    return await this.eventService.unlinkBlogFromEvent(eventId, blogId);
   }
 }

--- a/backend/src/event/event.service.spec.ts
+++ b/backend/src/event/event.service.spec.ts
@@ -8,7 +8,6 @@ import { BlogDatabaseService } from "../database/db.blog.service";
 describe("EventService", () => {
   let service: EventService;
   let dbService: EventDatabaseService;
-  let blogDbService: BlogDatabaseService;
 
   const mockEvent: EventDto = {
     id: 1,
@@ -56,7 +55,6 @@ describe("EventService", () => {
 
     service = module.get<EventService>(EventService);
     dbService = module.get<EventDatabaseService>(EventDatabaseService);
-    blogDbService = module.get<BlogDatabaseService>(BlogDatabaseService);
   });
 
   it("should be defined", () => {
@@ -185,51 +183,6 @@ describe("EventService", () => {
       await expect(service.deleteEvent(999)).rejects.toThrow(
         "Failed to delete record",
       );
-    });
-  });
-
-  // ... existing tests ...
-
-  describe("-- Blogs --", () => {
-    describe("getEventBlogs", () => {
-      it("should return all blogs linked to an event", async () => {
-        const expectedBlogs = [mockBlog];
-        // Note: You need to add `getBlogsOfEvent` to your EventDatabaseService mock in beforeEach
-        dbService.getBlogsOfEvent = jest.fn().mockResolvedValue(expectedBlogs);
-
-        const result = await service.getEventBlogs(1);
-
-        expect(result).toEqual(expectedBlogs);
-        expect(dbService.getBlogsOfEvent).toHaveBeenCalledWith(1);
-        expect(dbService.getBlogsOfEvent).toHaveBeenCalledTimes(1);
-      });
-    });
-
-    describe("linkBlogToEvent", () => {
-      it("should link a blog to an event and return the blog", async () => {
-        // Note: Ensure `linkBlogWithEventID` is in your EventDatabaseService mock
-        dbService.linkBlogWithEventID = jest.fn().mockResolvedValue(undefined);
-
-        const result = await service.linkBlogToEvent(1, 2);
-
-        expect(dbService.linkBlogWithEventID).toHaveBeenCalledWith(2, 1); // blogId first, then eventId
-        expect(blogDbService.getBlogById).toHaveBeenCalledWith(2);
-        expect(result).toEqual(mockBlog);
-      });
-    });
-
-    describe("unlinkBlogFromEvent", () => {
-      it("should unlink a blog from an event and return the event", async () => {
-        // Note: Ensure `deleteBlogFromEvent` is in your EventDatabaseService mock
-        dbService.deleteBlogFromEvent = jest.fn().mockResolvedValue(undefined);
-        dbService.getEventById = jest.fn().mockResolvedValue(mockEvent);
-
-        const result = await service.unlinkBlogFromEvent(1, 2);
-
-        expect(dbService.deleteBlogFromEvent).toHaveBeenCalledWith(1, 2);
-        expect(dbService.getEventById).toHaveBeenCalledWith(1);
-        expect(result).toEqual(mockEvent);
-      });
     });
   });
 

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -1,19 +1,10 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
-import type {
-  BlogDto,
-  CreateEventDto,
-  EventDto,
-  UpdateEventDto,
-} from "../dto/dto";
+import type { CreateEventDto, EventDto, UpdateEventDto } from "../dto/dto";
 import { EventDatabaseService } from "../database/db.event.service";
-import { BlogDatabaseService } from "../database/db.blog.service";
 
 @Injectable()
 export class EventService {
-  constructor(
-    private readonly eventDBService: EventDatabaseService,
-    private readonly blogDBService: BlogDatabaseService,
-  ) {}
+  constructor(private readonly eventDBService: EventDatabaseService) {}
 
   /**
    * Fetches all EventDto objects from the DBService
@@ -81,42 +72,6 @@ export class EventService {
    */
   async createEvent(newEvent: CreateEventDto): Promise<EventDto> {
     return await this.eventDBService.createEvent(newEvent);
-  }
-
-  // -- Blogs -- //
-
-  /**
-   * Returns all Blog objects linked to an Event.
-   * @param eventId The ID of the Event.
-   * @returns A list of Blogs.
-   */
-  async getEventBlogs(eventId: number): Promise<BlogDto[]> {
-    return await this.eventDBService.getBlogsOfEvent(eventId);
-  }
-
-  /**
-   * Links a Blog to an Event.
-   * @param eventId The ID of the Event in question.
-   * @param blogId The ID of the Blog in question.
-   * @returns The Blog that was just linked to the Event.
-   */
-  async linkBlogToEvent(eventId: number, blogId: number): Promise<BlogDto> {
-    await this.eventDBService.linkBlogWithEventID(blogId, eventId);
-    return await this.blogDBService.getBlogById(blogId);
-  }
-
-  /**
-   * Unlinks a Blog from an Event.
-   * @param eventId The ID of the Event in question.
-   * @param blogId The ID of the Blog in question.
-   * @returns The Event the Blog was unlinked from.
-   */
-  async unlinkBlogFromEvent(
-    eventId: number,
-    blogId: number,
-  ): Promise<EventDto> {
-    await this.eventDBService.deleteBlogFromEvent(eventId, blogId);
-    return await this.eventDBService.getEventById(eventId);
   }
 }
 


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR removes unwanted functionality
* Removed all mentions of Blogs in the Event Services and Controller.

## 🛠️ TESTING

Tests have been altered to reflect this change.

## 📝 DOCUMENTATION

Documentation doesn't change, since the only thing that happened was deletes.

## 🔍 HOW TO TEST

You can't really test this other than look if the endpoints are still there.

## ⚠️ REMAINING ISSUES

The DB tables should be cleaned up when this is merged, otherwise this would be left in the DB when it won't be used anymore.

See #112 

## ✅ CLOSED ISSUES
- Closes #90 
