### PR TITLE
Insert Productions

### DIFF
--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -279,6 +279,64 @@ export class ProductionDatabaseService {
   }
 
   /**
+   * Forcibly insert a production with an already existing ID into the Database.
+   * Will either create a new production or override an existing one.
+   * @param production The production object that we want to insert.
+   * @returns That same production object but returned from the Database.
+   */
+  async insertProduction(
+    production: ProductionDto
+  ): Promise<ProductionDto> {
+
+    const query = `
+      INSERT INTO productions (
+        id,
+        titel,
+        ondertitel,
+        description1,
+        description2,
+        genre,
+        planning_id
+      )
+      VALUES ($1,$2,$3,$4,$5,$6,$7)
+      ON CONFLICT (id)
+      DO UPDATE SET
+        titel = EXCLUDED.titel,
+        ondertitel = EXCLUDED.ondertitel,
+        description1 = EXCLUDED.description1,
+        description2 = EXCLUDED.description2,
+        genre = EXCLUDED.genre,
+        planning_id = EXCLUDED.planning_id
+      RETURNING
+        id,
+        titel,
+        ondertitel,
+        description1,
+        description2,
+        genre,
+        planning_id
+    `;
+
+    const values = [
+      production.id,
+      production.titel,
+      production.ondertitel ?? null,
+      production.description1 ?? null,
+      production.description2 ?? null,
+      production.genre,
+      production.planning_id ?? null,
+    ];
+
+    const result = await this.db.query<ProductionDto>(query, values);
+
+    if (!result.length) {
+      throw new Error("Failed to insert Production.");
+    }
+
+    return result[0];
+  }
+
+  /**
    * Update function for productions. Updates the production in the database.
    * @param production must be of the type "UpdateProduction", gives the freedom to define only what needs to be updated.
    * The id field in the production MUST be defined.

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -279,15 +279,12 @@ export class ProductionDatabaseService {
   }
 
   /**
-   * Forcibly insert a production with an already existing ID into the Database.
-   * Will either create a new production or override an existing one.
+   * UNSAFE version of createProduction. Will override if a Production
+   * already exists with the same ID.
    * @param production The production object that we want to insert.
    * @returns That same production object but returned from the Database.
    */
-  async insertProduction(
-    production: ProductionDto
-  ): Promise<ProductionDto> {
-
+  async insertProduction(production: ProductionDto): Promise<ProductionDto> {
     const query = `
       INSERT INTO productions (
         id,

--- a/backend/src/production/controllers/production.controller.spec.ts
+++ b/backend/src/production/controllers/production.controller.spec.ts
@@ -38,6 +38,7 @@ describe("ProductionController", () => {
             modifyProduction: jest.fn().mockResolvedValue(mockProduction),
             deleteProduction: jest.fn().mockResolvedValue(undefined),
             createProduction: jest.fn(),
+            insertProduction: jest.fn(),
           },
         },
       ],
@@ -212,6 +213,55 @@ describe("ProductionController", () => {
 
       await expect(controller.createProduction(newProduction)).rejects.toThrow(
         "Failed to create production",
+      );
+    });
+  });
+
+  describe("insertProduction", () => {
+    it("should insert a production successfully", async () => {
+      // 1. Define the full ProductionDto (including the ID)
+      const productionToInsert: ProductionDto = {
+        id: 999, // Since this is an insert of existing data, it has an ID
+        titel: "New Show",
+        ondertitel: "Exciting",
+        description1: "Awesome description",
+        description2: "Even more awesome",
+        genre: "Comedy",
+        planning_id: "2",
+      };
+
+      // 2. Spy on the service's insertProduction method
+      jest
+        .spyOn(service, "insertProduction")
+        .mockResolvedValueOnce(productionToInsert);
+
+      // 3. Call the controller method
+      const result = await controller.insertProduction(productionToInsert);
+
+      // 4. Verify the controller passed the right data to the service
+      expect(service.insertProduction).toHaveBeenCalledWith(productionToInsert);
+      expect(result).toEqual(productionToInsert);
+    });
+
+    it("should handle service errors when insertion fails", async () => {
+      const productionToInsert: ProductionDto = {
+        id: 999,
+        titel: "New Show",
+        ondertitel: "Exciting",
+        description1: "Awesome description",
+        description2: "Even more awesome",
+        genre: "Comedy",
+        planning_id: "2",
+      };
+
+      // Mock the service throwing an error
+      jest
+        .spyOn(service, "insertProduction")
+        .mockRejectedValueOnce(new Error("Failed to insert production"));
+
+      // Verify the controller propagates the error
+      await expect(controller.insertProduction(productionToInsert)).rejects.toThrow(
+        "Failed to insert production",
       );
     });
   });

--- a/backend/src/production/controllers/production.controller.ts
+++ b/backend/src/production/controllers/production.controller.ts
@@ -144,6 +144,11 @@ export class ProductionController {
     return await this.productionService.createProduction(newProduction);
   }
 
+  /**
+   * Responds to a POST to "/production/insert".
+   * @param production The new ProductionDto data we want to add/insert forcibly.
+   * @returns 
+   */
   @ApiOperation({ summary: "Inserts a Production." })
   @ApiBody({ type: ProductionDto })
   @ApiOkResponse({ type: ProductionDto, description: "Production inserted." })

--- a/backend/src/production/controllers/production.controller.ts
+++ b/backend/src/production/controllers/production.controller.ts
@@ -141,6 +141,17 @@ export class ProductionController {
   async createProduction(
     @Body() newProduction: CreateProductionDto,
   ): Promise<ProductionDto> {
-    return this.productionService.createProduction(newProduction);
+    return await this.productionService.createProduction(newProduction);
+  }
+
+  @ApiOperation({ summary: "Inserts a Production." })
+  @ApiBody({ type: ProductionDto })
+  @ApiOkResponse({ type: ProductionDto, description: "Production inserted." })
+  @Post("insert")
+  @UsePipes(new ZodValidationPipe(ProductionSchema))
+  async insertProduction(
+    @Body() production: ProductionDto,
+  ): Promise<ProductionDto> {
+    return await this.productionService.insertProduction(production); 
   }
 }

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -53,10 +53,10 @@ describe("ProductionService", () => {
             updateProduction: jest.fn().mockResolvedValue(mockProduction),
             deleteProduction: jest.fn().mockResolvedValue(undefined),
             createProduction: jest.fn(),
+            insertProduction: jest.fn(),
             getBlogsOfProduction: jest.fn(),
             linkBlogWithProductionID: jest.fn(),
             deleteBlogFromProduction: jest.fn(),
-            // New mock methods
             addTagToProduction: jest.fn(),
             removeTagFromProduction: jest.fn(),
           },
@@ -483,5 +483,50 @@ describe("ProductionService", () => {
     });
   });
 
-  // TODO: Add tests for insert!!
+  describe("insertProduction", () => {
+    it("should insert a production successfully", async () => {
+      // 1. Notice we use ProductionDto now and include the ID
+      const productionToInsert: ProductionDto = {
+        id: 999, 
+        titel: "New Show",
+        ondertitel: "Exciting",
+        description1: "Awesome description",
+        description2: "Even more awesome",
+        genre: "Comedy",
+        planning_id: "2",
+      };
+
+      // 2. Spy on insertProduction instead of createProduction
+      jest
+        .spyOn(dbService, "insertProduction")
+        .mockResolvedValueOnce(productionToInsert);
+
+      // 3. Call the insert service method
+      const result = await service.insertProduction(productionToInsert);
+
+      // 4. Verify the correct method was called with the full DTO
+      expect(dbService.insertProduction).toHaveBeenCalledWith(productionToInsert);
+      expect(result).toEqual(productionToInsert);
+    });
+
+    it("should handle database errors when insertion fails", async () => {
+      const productionToInsert: ProductionDto = {
+        id: 999,
+        titel: "New Show",
+        ondertitel: "Exciting",
+        description1: "Awesome description",
+        description2: "Even more awesome",
+        genre: "Comedy",
+        planning_id: "2",
+      };
+
+      jest
+        .spyOn(dbService, "insertProduction")
+        .mockRejectedValueOnce(new Error("Failed to insert production"));
+
+      await expect(service.insertProduction(productionToInsert)).rejects.toThrow(
+        "Failed to insert production",
+      );
+    });
+  });
 });

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -482,4 +482,6 @@ describe("ProductionService", () => {
       );
     });
   });
+
+  // TODO: Add tests for insert!!
 });

--- a/backend/src/production/production.service.ts
+++ b/backend/src/production/production.service.ts
@@ -96,6 +96,17 @@ export class ProductionService {
     return await this.productionDBService.createProduction(newProduction);
   }
 
+  /**
+   * Insert a Production into the database, ignoring any existing ones with the same id.
+   * @param production The Production we want to add.
+   * @returns The inserted Production.
+   */
+  async insertProduction(
+    production: ProductionDto,
+  ): Promise<ProductionDto> {
+    return await this.productionDBService.insertProduction(production);
+  }
+
   // -- Blogs -- //
 
   /**

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -79,6 +79,7 @@ const mockProductionDbService = () => ({
   getProductions: jest.fn().mockResolvedValue([mockProduction]),
   getProductionById: jest.fn().mockResolvedValue(mockProduction),
   createProduction: jest.fn().mockResolvedValue(mockProduction),
+  insertProduction: jest.fn().mockResolvedValue(mockProduction),
   updateProduction: jest.fn().mockResolvedValue(mockProduction),
   deleteProduction: jest.fn().mockResolvedValue(undefined),
   getBlogsOfProduction: jest.fn().mockResolvedValue([mockBlog]),
@@ -470,6 +471,45 @@ describe("ProductionController (e2e)", () => {
         .post("/production")
         .send({ titel: "Incomplete" })
         .expect(400);
+    });
+  });
+
+  // POST /production/insert
+  describe("POST /production/insert", () => {
+    it("should return 201 with the inserted production", () => {
+      // Note: NestJS @Post() defaults to 201 Created. 
+      // If you added @HttpCode(200) to your controller, change this to .expect(200)
+      return request(app.getHttpServer())
+        .post("/production/insert") 
+        .send(mockProduction)
+        .expect(201) 
+        .expect(mockProduction); // Assuming your mock is set up to return the payload
+    });
+
+    it("should call productionDb.insertProduction with the payload", async () => {
+      await request(app.getHttpServer())
+        .post("/production/insert")
+        .send(mockProduction);
+      
+      // Verify the right DB method was triggered
+      expect(productionDb.insertProduction).toHaveBeenCalledWith(mockProduction);
+    });
+
+    it("should return 400 when the required 'id' is missing", () => {
+      // Destructure to easily create a payload without the ID
+      const { id, ...payloadWithoutId } = mockProduction;
+
+      return request(app.getHttpServer())
+        .post("/production/insert")
+        .send(payloadWithoutId)
+        .expect(400); // Zod should block this
+    });
+
+    it("should return 400 when other required fields are missing", () => {
+      return request(app.getHttpServer())
+        .post("/production/insert")
+        .send({ id: 999, titel: "Incomplete" }) // Has ID, but missing genre, etc.
+        .expect(400); // Zod should also block this
     });
   });
 


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature
* Adds an endpoint that allows for inserting productions (forcibly). This will override any already existing production with the ID specified in the new one.

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

**Missing tests:**
* Still need to write tests for this code.

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code

**Missing documentation:**
* Documentation is already there.

## 🔍 HOW TO TEST

Just try it out via the Swagger UI. It should be able to add Productions that don't already exist or overwrite existing ones.

## ✅ CLOSED ISSUES
- Closes #109 
