### PR TITLE
Fix REST endpoint names

### DIFF
--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -21,186 +21,190 @@ describe("AuthGuards tests", () => {
 
   describe("Event endpoints authentication", () => {
     it("GET /events should work without API key", async () => {
-      await request(app.getHttpServer()).get("/event").expect(200);
+      await request(app.getHttpServer()).get("/events").expect(200);
     });
 
     it("GET /events/:id should work without API key", async () => {
-      await request(app.getHttpServer()).get("/event/1").send({}).expect(200);
+      await request(app.getHttpServer()).get("/events/1").send({}).expect(200);
     });
 
     it("POST /events should fail without API key", async () => {
-      await request(app.getHttpServer()).post("/event").send({}).expect(401);
+      await request(app.getHttpServer()).post("/events").send({}).expect(401);
     });
 
     it("PUT /events/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).put("/event/1").send({}).expect(401);
+      await request(app.getHttpServer()).put("/events/1").send({}).expect(401);
     });
 
     it("DELETE /events/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).delete("/event/1").expect(401);
+      await request(app.getHttpServer()).delete("/events/1").expect(401);
     });
 
     it("GET /events/:eventId/locations", async () => {
-      await request(app.getHttpServer()).get("/event/1/location").expect(200);
+      await request(app.getHttpServer()).get("/events/1/locations").expect(200);
     });
   });
 
   describe("Event - Location endpoints authentication", () => {
     it("GET /events/:eventId/locations should work without API key", async () => {
-      await request(app.getHttpServer()).get("/event/1/location").expect(200);
+      await request(app.getHttpServer()).get("/events/1/locations").expect(200);
     });
 
     it("PUT /events/:eventId/locations/:locationId should fail without API key.", async () => {
-      await request(app.getHttpServer()).put("/event/1/location/1").expect(401);
+      await request(app.getHttpServer())
+        .put("/events/1/locations/1")
+        .expect(401);
     });
 
     it("DELETE /events/:eventId/locations should fail without API key.", async () => {
       await request(app.getHttpServer())
-        .delete("/event/1/location")
+        .delete("/events/1/locations")
         .expect(401);
     });
   });
 
   describe("Production endpoints authentication", () => {
     it("GET /productions should work without API key", async () => {
-      await request(app.getHttpServer()).get("/production").expect(200);
+      await request(app.getHttpServer()).get("/productions").expect(200);
     });
 
     it("GET /productions/:id should work without API key", async () => {
       await request(app.getHttpServer())
-        .get("/production/1")
+        .get("/productions/1")
         .send({})
         .expect(200);
     });
 
     it("POST /productions should fail without API key", async () => {
       await request(app.getHttpServer())
-        .post("/production")
+        .post("/productions")
         .send({})
         .expect(401);
     });
 
     it("PUT /productions/:id should fail without API key", async () => {
       await request(app.getHttpServer())
-        .put("/production/1")
+        .put("/productions/1")
         .send({})
         .expect(401);
     });
 
     it("DELETE /productions/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).delete("/production/1").expect(401);
+      await request(app.getHttpServer()).delete("/productions/1").expect(401);
     });
 
     it("PATCH /productions/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).patch("/production/1").expect(401);
+      await request(app.getHttpServer()).patch("/productions/1").expect(401);
     });
   });
 
   describe("Production-blog endpoints authentication", () => {
     it("GET /productions/:id/blogs should work without API key", async () => {
-      await request(app.getHttpServer()).get("/production/1/blog").expect(200);
+      await request(app.getHttpServer())
+        .get("/productions/1/blogs")
+        .expect(200);
     });
 
     it("PUT /productions/:id/blogs/:id should fail without API key", async () => {
       await request(app.getHttpServer())
-        .put("/production/1/blog/1")
+        .put("/productions/1/blogs/1")
         .send({})
         .expect(401);
     });
 
     it("DELETE /productions/:id/blogs/:id  should fail without API key", async () => {
       await request(app.getHttpServer())
-        .delete("/production/1/blog/1")
+        .delete("/productions/1/blogs/1")
         .expect(401);
     });
   });
 
   describe("Production-tag endpoints authentication", () => {
     it("GET /productions/:id/tags should work without API key", async () => {
-      await request(app.getHttpServer()).get("/production/1/tag").expect(200);
+      await request(app.getHttpServer()).get("/productions/1/tags").expect(200);
     });
 
     it("PUT /productions/:id/tags/:id should fail without API key", async () => {
       await request(app.getHttpServer())
-        .put("/production/1/tag/1")
+        .put("/productions/1/tags/1")
         .send({})
         .expect(401);
     });
 
     it("DELETE /productions/:id/tags/:id  should fail without API key", async () => {
       await request(app.getHttpServer())
-        .delete("/production/1/tag/1")
+        .delete("/productions/1/tags/1")
         .expect(401);
     });
   });
 
   describe("Tag endpoints authentication", () => {
     it("GET /tags should work without API key", async () => {
-      await request(app.getHttpServer()).get("/tag").expect(200);
+      await request(app.getHttpServer()).get("/tags").expect(200);
     });
 
     it("POST /tags should fail without API key", async () => {
-      await request(app.getHttpServer()).post("/tag").send({}).expect(401);
+      await request(app.getHttpServer()).post("/tags").send({}).expect(401);
     });
 
     it("GET /tags/:id should work without API key", async () => {
-      await request(app.getHttpServer()).get("/tag/1").send({}).expect(200);
+      await request(app.getHttpServer()).get("/tags/1").send({}).expect(200);
     });
 
     it("DELETE /tags/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).delete("/tag/1").expect(401);
+      await request(app.getHttpServer()).delete("/tags/1").expect(401);
     });
 
     it("PATCH /tags/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).patch("/tag/1").expect(401);
+      await request(app.getHttpServer()).patch("/tags/1").expect(401);
     });
   });
 
   describe("Blog endpoints authentication", () => {
     it("GET /blogs should work without API key", async () => {
-      await request(app.getHttpServer()).get("/blog").expect(200);
+      await request(app.getHttpServer()).get("/blogs").expect(200);
     });
 
     it("POST /blogs should fail without API key", async () => {
-      await request(app.getHttpServer()).post("/blog").send({}).expect(401);
+      await request(app.getHttpServer()).post("/blogs").send({}).expect(401);
     });
 
     it("GET /blogs/:id should work without API key", async () => {
-      await request(app.getHttpServer()).get("/blog/1").send({}).expect(200);
+      await request(app.getHttpServer()).get("/blogs/1").send({}).expect(200);
     });
 
     it("DELETE /blogs/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).delete("/blog/1").expect(401);
+      await request(app.getHttpServer()).delete("/blogs/1").expect(401);
     });
 
     it("PATCH /blogs/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).patch("/blog/1").expect(401);
+      await request(app.getHttpServer()).patch("/blogs/1").expect(401);
     });
 
     it("PUT /blogs/:id should fail without API key", async () => {
-      await request(app.getHttpServer()).put("/blog/1").expect(401);
+      await request(app.getHttpServer()).put("/blogs/1").expect(401);
     });
   });
 
   describe("Location endpoints authentication", () => {
     it("GET /locations should work without API key", async () => {
-      await request(app.getHttpServer()).get("/location").expect(200);
+      await request(app.getHttpServer()).get("/locations").expect(200);
     });
 
     it("GET /locations/:locationId should work without API key", async () => {
-      await request(app.getHttpServer()).get("/location/1").expect(200);
+      await request(app.getHttpServer()).get("/locations/1").expect(200);
     });
 
     it("POST /locations should fail without API key", async () => {
-      await request(app.getHttpServer()).post("/location").expect(401);
+      await request(app.getHttpServer()).post("/locations").expect(401);
     });
 
     it("PATCH /locations should fail without API key", async () => {
-      await request(app.getHttpServer()).patch("/location").expect(401);
+      await request(app.getHttpServer()).patch("/locations").expect(401);
     });
 
     it("DELETE /locations/:locationId should fail without API key", async () => {
-      await request(app.getHttpServer()).delete("/location/1").expect(401);
+      await request(app.getHttpServer()).delete("/locations/1").expect(401);
     });
   });
 

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -22,12 +22,12 @@ import {
 } from "@nestjs/swagger";
 import { ApiKeyGuard } from "../auth/authGuard";
 
-@Controller("blog")
+@Controller("blogs")
 export class BlogController {
   constructor(private readonly blogService: BlogService) {}
 
   /**
-   * Responds to a GET to "/blog"
+   * Responds to a GET to "/blogs"
    * @returns A list of all Blog objects.
    */
   @ApiOperation({ summary: "Returns all blogs." })
@@ -42,19 +42,21 @@ export class BlogController {
   }
 
   /**
-   * Responds to a GET to "/blog/:id"
-   * @param id The ID of the Blog that will be fetched.
+   * Responds to a GET to "/blogs/:blogId"
+   * @param blogId The ID of the Blog that will be fetched.
    * @returns The Blog corresponding to ID if there was one.
    */
   @ApiOperation({ summary: "Returns a single blog." })
   @ApiOkResponse({ type: BlogDto, description: "Found Blog." })
-  @Get(":id")
-  async getBlogById(@Param("id", ParseIntPipe) id: number): Promise<BlogDto> {
-    return await this.blogService.getBlogById(id);
+  @Get(":blogId")
+  async getBlogById(
+    @Param("blogId", ParseIntPipe) blogId: number,
+  ): Promise<BlogDto> {
+    return await this.blogService.getBlogById(blogId);
   }
 
   /**
-   * Responds to a POST to "/blog"
+   * Responds to a POST to "/blogs"
    * @param createBlog The Blog object that should be created, excluding the id.
    * @returns The newly created Blog object.
    */
@@ -71,8 +73,8 @@ export class BlogController {
   }
 
   /**
-   * Responds to a PUT to "/blog/:id"
-   * @param id The ID of the Blog we want to replace.
+   * Responds to a PUT to "/blogs/:blogId"
+   * @param blogId The ID of the Blog we want to replace.
    * @param blog The Blog we want to replace it with.
    * @returns The replaced Blog.
    */
@@ -81,17 +83,17 @@ export class BlogController {
   @ApiOperation({ summary: "Replaces an existing blog." })
   @ApiBody({ type: BlogDto })
   @ApiOkResponse({ type: BlogDto, description: "Replaced Blog." })
-  @Put(":id")
+  @Put(":blogId")
   async replaceBlog(
-    @Param("id", ParseIntPipe) id: number,
+    @Param("blogId", ParseIntPipe) blogId: number,
     @Body(new ZodValidationPipe(BlogSchema)) blog: BlogDto,
   ): Promise<BlogDto> {
-    return await this.blogService.replaceBlog(id, blog);
+    return await this.blogService.replaceBlog(blogId, blog);
   }
 
   /**
-   * Responds to a PATCH to "/blog/:id"
-   * @param id The ID of the Blog we want to modify.
+   * Responds to a PATCH to "/blogs/:blogId"
+   * @param blogId The ID of the Blog we want to modify.
    * @param blog The Partial Blog object with fields filled that we want to modify.
    * @returns The modified Blog.
    */
@@ -100,25 +102,27 @@ export class BlogController {
   @ApiOperation({ summary: "Modifies an existing blog." })
   @ApiBody({ type: UpdateBlogDto })
   @ApiOkResponse({ type: BlogDto, description: "Modified Blog." })
-  @Patch(":id")
+  @Patch(":blogId")
   async modifyBlog(
-    @Param("id", ParseIntPipe) id: number,
+    @Param("blogId", ParseIntPipe) blogId: number,
     @Body(new ZodValidationPipe(UpdateBlogSchema)) blog: UpdateBlogDto,
   ): Promise<BlogDto> {
-    return await this.blogService.modifyBlog(id, blog);
+    return await this.blogService.modifyBlog(blogId, blog);
   }
 
   /**
-   * Responds to a DELETE to "/blog/:id"
-   * @param id The ID of the Blog we want to delete.
+   * Responds to a DELETE to "/blogs/:blogId"
+   * @param blogId The ID of the Blog we want to delete.
    * @returns Nothing.
    */
   @UseGuards(ApiKeyGuard)
   @ApiSecurity("apiKey")
   @ApiOperation({ summary: "Delete an existing blog." })
   @ApiOkResponse({ description: "Deleted Blog." })
-  @Delete(":id")
-  async deleteBlog(@Param("id", ParseIntPipe) id: number): Promise<void> {
-    return await this.blogService.deleteBlog(id);
+  @Delete(":blogId")
+  async deleteBlog(
+    @Param("blogId", ParseIntPipe) blogId: number,
+  ): Promise<void> {
+    return await this.blogService.deleteBlog(blogId);
   }
 }

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -278,7 +278,7 @@ export class ProductionDatabaseService {
    * @param production The production object that we want to insert.
    * @returns That same production object but returned from the Database.
    */
-  async insertProduction(production: ProductionDto): Promise<ProductionDto> {
+  async upsertProduction(production: ProductionDto): Promise<ProductionDto> {
     const query = `
       INSERT INTO productions (
         id,

--- a/backend/src/event/controllers/event-location.controller.ts
+++ b/backend/src/event/controllers/event-location.controller.ts
@@ -17,13 +17,13 @@ import {
 import { LocationDto } from "../../dto/dto";
 import { ApiKeyGuard } from "../../auth/authGuard";
 
-@ApiTags("Event - Location")
-@Controller("event/:eventId/location")
+@ApiTags("Events - Locations")
+@Controller("events/:eventId/locations")
 export class EventLocationController {
   constructor(private readonly eventService: EventService) {}
 
   /**
-   * Responds to GET /event/:eventId/location
+   * Responds to GET /events/:eventId/locations
    * @param eventId ID in the URL of the request.
    * @returns The Location corresponding to this event.
    */
@@ -39,7 +39,7 @@ export class EventLocationController {
   }
 
   /**
-   * Responds to PUT to "/event/:eventId/location/:locationId".
+   * Responds to PUT to "/events/:eventId/locations/:locationId".
    * @param eventId The ID of the Event.
    * @param locationId The ID of the Location.
    */
@@ -58,7 +58,7 @@ export class EventLocationController {
   }
 
   /**
-   * Responds to a DELETE to "/event/:eventId/location".
+   * Responds to a DELETE to "/events/:eventId/locations".
    * @param eventId The ID of the Event.
    * @returns Nothing
    */

--- a/backend/src/event/controllers/event.controller.ts
+++ b/backend/src/event/controllers/event.controller.ts
@@ -34,7 +34,7 @@ import {
   ApiSecurity,
 } from "@nestjs/swagger";
 
-@Controller("event")
+@Controller("events")
 export class EventController {
   constructor(private readonly eventService: EventService) {}
 
@@ -56,21 +56,22 @@ export class EventController {
   }
 
   /**
-   * Responds to GET /events/:id
-   * @param id ID in the URL of the request.
+   * Responds to GET /events/:eventId
+   * @param eventId ID in the URL of the request.
    * @returns The EventDto object with corresponding ID
    */
-  // TODO: return multiple events with same production id
   @ApiOperation({ summary: "Returns the Event with the ID in the URL." })
   @ApiOkResponse({ type: EventDto, description: "Event Found." })
-  @Get(":id")
-  async getEventById(@Param("id", ParseIntPipe) id: number): Promise<EventDto> {
-    return await this.eventService.getEventById(id);
+  @Get(":eventId")
+  async getEventById(
+    @Param("eventId", ParseIntPipe) eventId: number,
+  ): Promise<EventDto> {
+    return await this.eventService.getEventById(eventId);
   }
 
   /**
-   * Responds to a PUT to "/event/:id".
-   * @param id ID in the URL of the request.
+   * Responds to a PUT to "/events/:eventId".
+   * @param eventId ID in the URL of the request.
    * @param event The parsed EventDto object.
    * @returns The updated EventDto object.
    */
@@ -79,17 +80,17 @@ export class EventController {
   @ApiOperation({ summary: "Replaces an existing Event." })
   @ApiBody({ type: EventDto })
   @ApiOkResponse({ type: EventDto, description: "Event replaced." })
-  @Put(":id")
+  @Put(":eventId")
   async replaceEvent(
-    @Param("id", ParseIntPipe) id: number,
+    @Param("eventId", ParseIntPipe) eventId: number,
     @Body(new ZodValidationPipe(EventSchema)) event: EventDto,
   ): Promise<EventDto> {
-    return await this.eventService.replaceEvent(id, event);
+    return await this.eventService.replaceEvent(eventId, event);
   }
 
   /**
-   * Responds to a PATCH to "/event/:id".
-   * @param id ID in the URL of the request.
+   * Responds to a PATCH to "/events/:eventId".
+   * @param eventId ID in the URL of the request.
    * @param patchData The partial EventDto object that is used to modify.
    * @returns The updated EventDto object.
    */
@@ -98,30 +99,32 @@ export class EventController {
   @ApiOperation({ summary: "Modifies an existing Event." })
   @ApiBody({ type: UpdateEventDto })
   @ApiOkResponse({ type: EventDto, description: "Event modified." })
-  @Patch(":id")
+  @Patch(":eventId")
   async modifyEvent(
-    @Param("id", ParseIntPipe) id: number,
+    @Param("eventId", ParseIntPipe) eventId: number,
     @Body(new ZodValidationPipe(UpdateEventSchema)) patchData: UpdateEventDto,
   ): Promise<EventDto> {
-    return await this.eventService.modifyEvent(id, patchData);
+    return await this.eventService.modifyEvent(eventId, patchData);
   }
 
   /**
-   * Responds to a DELETE to "/event/:id".
-   * @param id ID in the URL of the request.
+   * Responds to a DELETE to "/events/:eventId".
+   * @param eventId ID in the URL of the request.
    * @returns Nothing.
    */
   @UseGuards(ApiKeyGuard)
   @ApiSecurity("apiKey")
   @ApiOperation({ summary: "Deletes an Event." })
   @ApiOkResponse({ description: "Event deleted." })
-  @Delete(":id")
-  async deleteEvent(@Param("id", ParseIntPipe) id: number): Promise<void> {
-    return await this.eventService.deleteEvent(id);
+  @Delete(":eventId")
+  async deleteEvent(
+    @Param("eventId", ParseIntPipe) eventId: number,
+  ): Promise<void> {
+    return await this.eventService.deleteEvent(eventId);
   }
 
   /**
-   * Responds to a POST to "/event/".
+   * Responds to a POST to "/events".
    * @param newEvent The new EventDto data we want to add
    * @returns The newly created EventDto.
    */

--- a/backend/src/location/location.controller.ts
+++ b/backend/src/location/location.controller.ts
@@ -23,12 +23,12 @@ import { ZodValidationPipe } from "nestjs-zod";
 import { CreateLocationSchema, UpdateLocationSchema } from "@repo/common";
 import { ApiKeyGuard } from "../auth/authGuard";
 
-@Controller("location")
+@Controller("locations")
 export class LocationController {
   constructor(private readonly locationService: LocationService) {}
 
   /**
-   * Responds to a GET to "/location"
+   * Responds to a GET to "/locations"
    * @returns A list of all Locations.
    */
   @ApiOperation({ summary: "Fetches a list of all Locations." })
@@ -43,7 +43,7 @@ export class LocationController {
   }
 
   /**
-   * Responds to a GET to "/location/:locationId"
+   * Responds to a GET to "/locations/:locationId"
    * @param locationId The ID of the Location we want to find.
    * @returns The Location with that ID.
    */
@@ -60,7 +60,7 @@ export class LocationController {
   }
 
   /**
-   * Responds to a POST to "/location"
+   * Responds to a POST to "/locations"
    * @param createLocation The Location we want to create.
    * @returns The newly created Location.
    */
@@ -81,7 +81,7 @@ export class LocationController {
   }
 
   /**
-   * Responds to a PATCH to "/location"
+   * Responds to a PATCH to "/locations"
    * @param updateLocation The Location we want to update.
    * @returns The newly updated Location.
    */
@@ -102,7 +102,7 @@ export class LocationController {
   }
 
   /**
-   * Responds to a DELETE to "/location/:locationId"
+   * Responds to a DELETE to "/locations/:locationId"
    * @param locationId The ID of the Location we want to delete.
    */
   @UseGuards(ApiKeyGuard)

--- a/backend/src/production/controllers/production-blog.controller.ts
+++ b/backend/src/production/controllers/production-blog.controller.ts
@@ -21,12 +21,12 @@ import { ApiKeyGuard } from "../../auth/authGuard";
  * Handles the Relationships between Productions and Blogs.
  */
 @ApiTags("Production - Blog")
-@Controller("production/:productionId/blog")
+@Controller("productions/:productionId/blogs")
 export class ProductionBlogController {
   constructor(private readonly productionService: ProductionService) {}
 
   /**
-   * Responds to a GET to "/production/:productionId/blog".
+   * Responds to a GET to "/productions/:productionId/blogs".
    * @param productionId The id of the Production.
    * @returns A list of all Blog objects linked to this Production.
    */
@@ -44,7 +44,7 @@ export class ProductionBlogController {
   }
 
   /**
-   * Responds to a PUT to "/production/:productionId/blog/:blogId"
+   * Responds to a PUT to "/productions/:productionId/blogs/:blogId"
    * @param productionId ID of the Production.
    * @param blogId ID of the Blog.
    * @returns The newly linked Blog object.
@@ -65,7 +65,7 @@ export class ProductionBlogController {
   }
 
   /**
-   * Responds to a DELETE to "/production/:productionId/blog/:blogId"
+   * Responds to a DELETE to "/productions/:productionId/blogs/:blogId"
    * @param productionId ID of the Production.
    * @param blogId ID of the Blog.
    * @returns The Production we just unlinked the Blog from.

--- a/backend/src/production/controllers/production-tag.controller.ts
+++ b/backend/src/production/controllers/production-tag.controller.ts
@@ -21,12 +21,12 @@ import { ApiKeyGuard } from "../../auth/authGuard";
  * Handles the Relationships between Productions and Tags.
  */
 @ApiTags("Production - Tag")
-@Controller("production/:productionId/tag")
+@Controller("productions/:productionId/tags")
 export class ProductionTagController {
   constructor(private readonly productionService: ProductionService) {}
 
   /**
-   * Responds to GET /production/:productionId/tag
+   * Responds to GET /productions/:productionId/tags
    * @param productionId ID in the URL of the request.
    * @returns The list of Tag objects for the Production
    */
@@ -42,7 +42,7 @@ export class ProductionTagController {
   }
 
   /**
-   * Responds to PUT to "/production/:productionId/tag/:tagId".
+   * Responds to PUT to "/productions/:productionId/tags/:tagId".
    * @param productionId The ID of the Production.
    * @param tagId The ID of the Tag.
    * @returns The altered Production.
@@ -63,7 +63,7 @@ export class ProductionTagController {
   }
 
   /**
-   * Responds to a DELETE to "/production/:productionId/tag/:tagId".
+   * Responds to a DELETE to "/productions/:productionId/tags/:tagId".
    * @param productionId The ID of the Production.
    * @param tagId The ID of the Tag.
    * @returns The altered Production.

--- a/backend/src/production/controllers/production.controller.spec.ts
+++ b/backend/src/production/controllers/production.controller.spec.ts
@@ -38,7 +38,7 @@ describe("ProductionController", () => {
             modifyProduction: jest.fn().mockResolvedValue(mockProduction),
             deleteProduction: jest.fn().mockResolvedValue(undefined),
             createProduction: jest.fn(),
-            insertProduction: jest.fn(),
+            upsertProduction: jest.fn(),
           },
         },
       ],
@@ -221,53 +221,6 @@ describe("ProductionController", () => {
       await expect(controller.createProduction(newProduction)).rejects.toThrow(
         "Failed to create production",
       );
-    });
-  });
-
-  describe("insertProduction", () => {
-    it("should insert a production successfully", async () => {
-      // 1. Define the full ProductionDto (including the ID)
-      const productionToInsert: ProductionDto = {
-        id: 999, // Since this is an insert of existing data, it has an ID
-        titel: "New Show",
-        ondertitel: "Exciting",
-        description1: "Awesome description",
-        description2: "Even more awesome",
-        planning_id: "2",
-      };
-
-      // 2. Spy on the service's insertProduction method
-      jest
-        .spyOn(service, "insertProduction")
-        .mockResolvedValueOnce(productionToInsert);
-
-      // 3. Call the controller method
-      const result = await controller.insertProduction(productionToInsert);
-
-      // 4. Verify the controller passed the right data to the service
-      expect(service.insertProduction).toHaveBeenCalledWith(productionToInsert);
-      expect(result).toEqual(productionToInsert);
-    });
-
-    it("should handle service errors when insertion fails", async () => {
-      const productionToInsert: ProductionDto = {
-        id: 999,
-        titel: "New Show",
-        ondertitel: "Exciting",
-        description1: "Awesome description",
-        description2: "Even more awesome",
-        planning_id: "2",
-      };
-
-      // Mock the service throwing an error
-      jest
-        .spyOn(service, "insertProduction")
-        .mockRejectedValueOnce(new Error("Failed to insert production"));
-
-      // Verify the controller propagates the error
-      await expect(
-        controller.insertProduction(productionToInsert),
-      ).rejects.toThrow("Failed to insert production");
     });
   });
 });

--- a/backend/src/production/controllers/production.controller.ts
+++ b/backend/src/production/controllers/production.controller.ts
@@ -38,7 +38,7 @@ import { ApiKeyGuard } from "../../auth/authGuard";
 /**
  * Handles CORE functionality for Productions.
  */
-@Controller("production")
+@Controller("productions")
 export class ProductionController {
   constructor(private readonly productionService: ProductionService) {}
 
@@ -77,7 +77,7 @@ export class ProductionController {
   }
 
   /**
-   * Responds to a PUT to "/production/:productionId".
+   * Responds to a PUT to "/productions/:productionId".
    * @param productionId The ID in the URL.
    * @param production The parsed ProductionDto object.
    * @returns The newly updated ProductionDto.
@@ -99,7 +99,7 @@ export class ProductionController {
   }
 
   /**
-   * Responds to a PATCH to "/production/:productionId".
+   * Responds to a PATCH to "/productions/:productionId".
    * @param productionId The ID in the URL.
    * @param patchData The parsed UpdateProductionDto object.
    * @returns The newly updated ProductionDto.
@@ -122,7 +122,7 @@ export class ProductionController {
   }
 
   /**
-   * Responds to a DELETE to "/production/:productionId".
+   * Responds to a DELETE to "/productions/:productionId".
    * @param productionId The ID in the URL.
    * @returns Nothing.
    */
@@ -138,7 +138,7 @@ export class ProductionController {
   }
 
   /**
-   * Responds to a POST to "/production".
+   * Responds to a POST to "/productions".
    * @param newProduction The new ProductionDto data we want to add
    * @returns The newly created ProductionDto.
    */
@@ -153,23 +153,5 @@ export class ProductionController {
     @Body() newProduction: CreateProductionDto,
   ): Promise<ProductionDto> {
     return await this.productionService.createProduction(newProduction);
-  }
-
-  /**
-   * Responds to a POST to "/production/insert".
-   * @param production The new ProductionDto data we want to add/insert forcibly.
-   * @returns The inserted Production.
-   */
-  @UseGuards(ApiKeyGuard)
-  @ApiSecurity("apiKey")
-  @ApiOperation({ summary: "Inserts a Production." })
-  @ApiBody({ type: ProductionDto })
-  @ApiOkResponse({ type: ProductionDto, description: "Production inserted." })
-  @Post("insert")
-  @UsePipes(new ZodValidationPipe(ProductionSchema))
-  async insertProduction(
-    @Body() production: ProductionDto,
-  ): Promise<ProductionDto> {
-    return await this.productionService.insertProduction(production);
   }
 }

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -501,7 +501,7 @@ describe("ProductionService", () => {
       const result = await service.insertProduction(productionToInsert);
 
       // 4. Verify the correct method was called with the full DTO
-      expect(dbService.insertProduction).toHaveBeenCalledWith(
+      expect(dbService.upsertProduction).toHaveBeenCalledWith(
         productionToInsert,
       );
       expect(result).toEqual(productionToInsert);

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -52,7 +52,7 @@ describe("ProductionService", () => {
             updateProduction: jest.fn().mockResolvedValue(mockProduction),
             deleteProduction: jest.fn().mockResolvedValue(undefined),
             createProduction: jest.fn(),
-            insertProduction: jest.fn(),
+            upsertProduction: jest.fn().mockResolvedValue(mockProduction),
             getBlogsOfProduction: jest.fn(),
             linkBlogWithProductionID: jest.fn(),
             deleteBlogFromProduction: jest.fn(),
@@ -155,7 +155,7 @@ describe("ProductionService", () => {
   describe("replaceProduction", () => {
     it("should successfully replace and return the production", async () => {
       const result = await service.replaceProduction(1, mockProduction);
-      expect(dbService.updateProduction).toHaveBeenCalledWith(mockProduction);
+      expect(dbService.upsertProduction).toHaveBeenCalledWith(mockProduction);
       expect(result).toEqual(mockProduction);
     });
 
@@ -477,53 +477,6 @@ describe("ProductionService", () => {
       await expect(service.createProduction(newProduction)).rejects.toThrow(
         "Failed to create production",
       );
-    });
-  });
-
-  describe("insertProduction", () => {
-    it("should insert a production successfully", async () => {
-      // 1. Notice we use ProductionDto now and include the ID
-      const productionToInsert: ProductionDto = {
-        id: 999,
-        titel: "New Show",
-        ondertitel: "Exciting",
-        description1: "Awesome description",
-        description2: "Even more awesome",
-        planning_id: "2",
-      };
-
-      // 2. Spy on insertProduction instead of createProduction
-      jest
-        .spyOn(dbService, "insertProduction")
-        .mockResolvedValueOnce(productionToInsert);
-
-      // 3. Call the insert service method
-      const result = await service.insertProduction(productionToInsert);
-
-      // 4. Verify the correct method was called with the full DTO
-      expect(dbService.upsertProduction).toHaveBeenCalledWith(
-        productionToInsert,
-      );
-      expect(result).toEqual(productionToInsert);
-    });
-
-    it("should handle database errors when insertion fails", async () => {
-      const productionToInsert: ProductionDto = {
-        id: 999,
-        titel: "New Show",
-        ondertitel: "Exciting",
-        description1: "Awesome description",
-        description2: "Even more awesome",
-        planning_id: "2",
-      };
-
-      jest
-        .spyOn(dbService, "insertProduction")
-        .mockRejectedValueOnce(new Error("Failed to insert production"));
-
-      await expect(
-        service.insertProduction(productionToInsert),
-      ).rejects.toThrow("Failed to insert production");
     });
   });
 });

--- a/backend/src/production/production.service.ts
+++ b/backend/src/production/production.service.ts
@@ -50,7 +50,9 @@ export class ProductionService {
     if (id !== production.id)
       throw new BadRequestException("ID in the URL must match ID in the body.");
 
-    return await this.productionDBService.updateProduction(production);
+    // * NOTE: Using Upsert here will make sure that
+    // * if the production does not yet exist it is created instead.
+    return await this.productionDBService.upsertProduction(production);
   }
 
   /**
@@ -94,17 +96,6 @@ export class ProductionService {
     newProduction: CreateProductionDto,
   ): Promise<ProductionDto> {
     return await this.productionDBService.createProduction(newProduction);
-  }
-
-  /**
-   * Insert a Production into the database, ignoring any existing ones with the same id.
-   * @param production The Production we want to add.
-   * @returns The inserted Production.
-   */
-  async insertProduction(
-    production: ProductionDto,
-  ): Promise<ProductionDto> {
-    return await this.productionDBService.insertProduction(production);
   }
 
   // -- Blogs -- //

--- a/backend/src/tag/tag.controller.ts
+++ b/backend/src/tag/tag.controller.ts
@@ -21,12 +21,12 @@ import { ApiKeyGuard } from "../auth/authGuard";
 import { ZodValidationPipe } from "nestjs-zod";
 import { CreateTagSchema, UpdateTagSchema } from "@repo/common";
 
-@Controller("tag")
+@Controller("tags")
 export class TagController {
   constructor(private readonly tagService: TagService) {}
 
   /**
-   * Responds to GET /tag
+   * Responds to GET /tags
    * @returns All TagDto objects
    */
   @ApiOperation({ summary: "Returns all Tag objects." })
@@ -41,19 +41,21 @@ export class TagController {
   }
 
   /**
-   * Responds to GET /tag/:id
-   * @param id ID in the URL of the request.
+   * Responds to GET /tags/:tagId
+   * @param tagId ID in the URL of the request.
    * @returns The TagDto object with corresponding ID
    */
   @ApiOperation({ summary: "Returns the Tag with id in the URL." })
   @ApiOkResponse({ type: TagDto, description: "Tag Found." })
-  @Get(":id")
-  async getTagById(@Param("id", ParseIntPipe) id: number): Promise<TagDto> {
-    return await this.tagService.getTagById(id);
+  @Get(":tagId")
+  async getTagById(
+    @Param("tagId", ParseIntPipe) tagId: number,
+  ): Promise<TagDto> {
+    return await this.tagService.getTagById(tagId);
   }
 
   /**
-   * Responds to a POST to "/tag".
+   * Responds to a POST to "/tags".
    * @param createTag The new TagDto data we want to add
    * @returns The newly created TagDto.
    */
@@ -70,8 +72,8 @@ export class TagController {
   }
 
   /**
-   * Responds to a PATCH to "/tag/:id".
-   * @param id The ID in the URL.
+   * Responds to a PATCH to "/tags/:tagId".
+   * @param tagId The ID in the URL.
    * @param updateTag The parsed UpdateTagDto object.
    * @returns The newly updated TagDto.
    */
@@ -80,27 +82,27 @@ export class TagController {
   @ApiOperation({ summary: "Modifies an existing Tag." })
   @ApiBody({ type: UpdateTagDto })
   @ApiOkResponse({ type: TagDto, description: "Tag Modified." })
-  @Patch(":id")
+  @Patch(":tagId")
   async updateTag(
-    @Param("id", ParseIntPipe) id: number,
+    @Param("tagId", ParseIntPipe) tagId: number,
     @Body(new ZodValidationPipe(UpdateTagSchema)) updateTag: UpdateTagDto,
   ): Promise<TagDto> {
-    return await this.tagService.updateTag(id, updateTag);
+    return await this.tagService.updateTag(tagId, updateTag);
   }
 
   /**
-   * Responds to a DELETE to "/tag/:id".
-   * @param id The ID in the URL.
+   * Responds to a DELETE to "/tags/:tagId".
+   * @param tagId The ID in the URL.
    * @returns Nothing.
    */
   @UseGuards(ApiKeyGuard)
   @ApiSecurity("apiKey")
   @ApiOperation({ summary: "Deletes a Tag." })
   @ApiOkResponse({ description: "Tag Deleted." })
-  @Delete(":id")
+  @Delete(":tagId")
   async deleteTag(
-    @Param("id", ParseIntPipe) id: number,
+    @Param("tagId", ParseIntPipe) tagId: number,
   ): Promise<{ message: string }> {
-    return await this.tagService.deleteTag(id);
+    return await this.tagService.deleteTag(tagId);
   }
 }

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -96,8 +96,8 @@ const mockProductionDbService = () => ({
   getProductions: jest.fn().mockResolvedValue([mockProduction]),
   getProductionById: jest.fn().mockResolvedValue(mockProduction),
   createProduction: jest.fn().mockResolvedValue(mockProduction),
-  insertProduction: jest.fn().mockResolvedValue(mockProduction),
   updateProduction: jest.fn().mockResolvedValue(mockProduction),
+  upsertProduction: jest.fn().mockResolvedValue(mockProduction),
   deleteProduction: jest.fn().mockResolvedValue(undefined),
   getBlogsOfProduction: jest.fn().mockResolvedValue([mockBlog]),
   linkBlogWithProductionID: jest.fn().mockResolvedValue(undefined),
@@ -164,82 +164,82 @@ describe("BlogController (e2e)", () => {
     await app.close();
   });
 
-  // GET /blog
-  describe("GET /blog", () => {
+  // GET /blogs
+  describe("GET /blogs", () => {
     it("should return 200 with an array of blogs", () => {
       return request(app.getHttpServer())
-        .get("/blog")
+        .get("/blogs")
         .expect(200)
         .expect([mockBlog, mockBlog2]);
     });
 
     it("should call blogDb.getBlogs()", async () => {
-      await request(app.getHttpServer()).get("/blog");
+      await request(app.getHttpServer()).get("/blogs");
       expect(blogDb.getBlogs).toHaveBeenCalled();
     });
 
     it("should return 200 with an empty array when no blogs exist", async () => {
       jest.spyOn(blogDb, "getBlogs").mockResolvedValueOnce([]);
-      return request(app.getHttpServer()).get("/blog").expect(200).expect([]);
+      return request(app.getHttpServer()).get("/blogs").expect(200).expect([]);
     });
   });
 
-  // GET /blog/:id
-  describe("GET /blog/:id", () => {
+  // GET /blogs/:id
+  describe("GET /blogs/:id", () => {
     it("should return 200 with the correct blog", () => {
       return request(app.getHttpServer())
-        .get("/blog/1")
+        .get("/blogs/1")
         .expect(200)
         .expect(mockBlog);
     });
 
     it("should call blogDb.getBlogById with the correct id", async () => {
-      await request(app.getHttpServer()).get("/blog/1");
+      await request(app.getHttpServer()).get("/blogs/1");
       expect(blogDb.getBlogById).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).get("/blog/abc").expect(400);
+      return request(app.getHttpServer()).get("/blogs/abc").expect(400);
     });
 
     it("should propagate errors from the database", async () => {
       jest
         .spyOn(blogDb, "getBlogById")
         .mockRejectedValueOnce(new Error("Not Found"));
-      return request(app.getHttpServer()).get("/blog/999").expect(500);
+      return request(app.getHttpServer()).get("/blogs/999").expect(500);
     });
   });
 
-  // POST /blog
-  describe("POST /blog", () => {
+  // POST /blogs
+  describe("POST /blogs", () => {
     const createPayload = { titel: "New Blog", description: "New description" };
 
     it("should return 201 with the created blog", () => {
       return request(app.getHttpServer())
-        .post("/blog")
+        .post("/blogs")
         .send(createPayload)
         .expect(201)
         .expect(mockBlog);
     });
 
     it("should call blogDb.createBlog with the payload", async () => {
-      await request(app.getHttpServer()).post("/blog").send(createPayload);
+      await request(app.getHttpServer()).post("/blogs").send(createPayload);
       expect(blogDb.createBlog).toHaveBeenCalledWith(createPayload);
     });
 
     it("should return 400 when body is missing required fields", () => {
       return request(app.getHttpServer())
-        .post("/blog")
+        .post("/blogs")
         .send({ titel: "Only title" })
         .expect(400);
     });
   });
 
-  // PUT /blog/:id
-  describe("PUT /blog/:id", () => {
+  // PUT /blogs/:id
+  describe("PUT /blogs/:id", () => {
     it("should return 200 with the replaced blog when ids match", () => {
       return request(app.getHttpServer())
-        .put("/blog/1")
+        .put("/blogs/1")
         .send(mockBlog)
         .expect(200)
         .expect(mockBlog);
@@ -247,24 +247,24 @@ describe("BlogController (e2e)", () => {
 
     it("should return 400 when URL id and body id do not match", () => {
       return request(app.getHttpServer())
-        .put("/blog/2")
+        .put("/blogs/2")
         .send(mockBlog) // id: 1 in body
         .expect(400);
     });
 
     it("should return 400 when id param is not a number", () => {
       return request(app.getHttpServer())
-        .put("/blog/abc")
+        .put("/blogs/abc")
         .send(mockBlog)
         .expect(400);
     });
   });
 
-  // PATCH /blog/:id
-  describe("PATCH /blog/:id", () => {
+  // PATCH /blogs/:id
+  describe("PATCH /blogs/:id", () => {
     it("should return 200 with the modified blog", () => {
       return request(app.getHttpServer())
-        .patch("/blog/1")
+        .patch("/blogs/1")
         .send({ titel: "Updated title" })
         .expect(200)
         .expect(mockBlog);
@@ -272,32 +272,32 @@ describe("BlogController (e2e)", () => {
 
     it("should call blogDb.updateBlog", async () => {
       await request(app.getHttpServer())
-        .patch("/blog/1")
+        .patch("/blogs/1")
         .send({ titel: "Updated title" });
       expect(blogDb.updateBlog).toHaveBeenCalled();
     });
 
     it("should return 400 when id is not a number", () => {
       return request(app.getHttpServer())
-        .patch("/blog/abc")
+        .patch("/blogs/abc")
         .send({ titel: "Updated title" })
         .expect(400);
     });
   });
 
-  // DELETE /blog/:id
-  describe("DELETE /blog/:id", () => {
+  // DELETE /blogs/:id
+  describe("DELETE /blogs/:id", () => {
     it("should return 200 when blog is deleted", () => {
-      return request(app.getHttpServer()).delete("/blog/1").expect(200);
+      return request(app.getHttpServer()).delete("/blogs/1").expect(200);
     });
 
     it("should call blogDb.deleteBlog with the correct id", async () => {
-      await request(app.getHttpServer()).delete("/blog/1");
+      await request(app.getHttpServer()).delete("/blogs/1");
       expect(blogDb.deleteBlog).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).delete("/blog/abc").expect(400);
+      return request(app.getHttpServer()).delete("/blogs/abc").expect(400);
     });
   });
 });
@@ -317,67 +317,67 @@ describe("TagController (e2e)", () => {
     await app.close();
   });
 
-  // GET /tag
-  describe("GET /tag", () => {
+  // GET /tags
+  describe("GET /tags", () => {
     it("should return 200 with an array of tags", () => {
       return request(app.getHttpServer())
-        .get("/tag")
+        .get("/tags")
         .expect(200)
         .expect([mockTag, mockTag2]);
     });
 
     it("should return 200 with empty array when no tags exist", async () => {
       jest.spyOn(tagDb, "getTags").mockResolvedValueOnce([]);
-      return request(app.getHttpServer()).get("/tag").expect(200).expect([]);
+      return request(app.getHttpServer()).get("/tags").expect(200).expect([]);
     });
   });
 
-  // GET /tag/:id
-  describe("GET /tag/:id", () => {
+  // GET /tags/:id
+  describe("GET /tags/:id", () => {
     it("should return 200 with the correct tag", () => {
       return request(app.getHttpServer())
-        .get("/tag/1")
+        .get("/tags/1")
         .expect(200)
         .expect(mockTag);
     });
 
     it("should call tagDb.getTagById with the correct id", async () => {
-      await request(app.getHttpServer()).get("/tag/1");
+      await request(app.getHttpServer()).get("/tags/1");
       expect(tagDb.getTagById).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).get("/tag/abc").expect(400);
+      return request(app.getHttpServer()).get("/tags/abc").expect(400);
     });
   });
 
-  // POST /tag
-  describe("POST /tag", () => {
+  // POST /tags
+  describe("POST /tags", () => {
     const createPayload = { tag: "Thriller" };
 
     it("should return 201 with the created tag", () => {
       return request(app.getHttpServer())
-        .post("/tag")
+        .post("/tags")
         .send(createPayload)
         .expect(201)
         .expect(mockTag);
     });
 
     it("should call tagDb.createTag with the payload", async () => {
-      await request(app.getHttpServer()).post("/tag").send(createPayload);
+      await request(app.getHttpServer()).post("/tags").send(createPayload);
       expect(tagDb.createTag).toHaveBeenCalledWith(createPayload);
     });
 
     it("should return 400 when body is missing required field 'tag'", () => {
-      return request(app.getHttpServer()).post("/tag").send({}).expect(400);
+      return request(app.getHttpServer()).post("/tags").send({}).expect(400);
     });
   });
 
-  // PATCH /tag/:id
-  describe("PATCH /tag/:id", () => {
+  // PATCH /tags/:id
+  describe("PATCH /tags/:id", () => {
     it("should return 200 with the updated tag", () => {
       return request(app.getHttpServer())
-        .patch("/tag/1")
+        .patch("/tags/1")
         .send({ tag: "Thriller" })
         .expect(200)
         .expect(mockTag);
@@ -385,36 +385,36 @@ describe("TagController (e2e)", () => {
 
     it("should return 400 when body id does not match URL id", () => {
       return request(app.getHttpServer())
-        .patch("/tag/1")
+        .patch("/tags/1")
         .send({ id: 99, tag: "Other" })
         .expect(400);
     });
 
     it("should return 400 when id is not a number", () => {
       return request(app.getHttpServer())
-        .patch("/tag/abc")
+        .patch("/tags/abc")
         .send({ tag: "Something" })
         .expect(400);
     });
   });
 
-  // DELETE /tag/:id
-  describe("DELETE /tag/:id", () => {
+  // DELETE /tags/:id
+  describe("DELETE /tags/:id", () => {
     it("should return 200 with a success message", async () => {
       const response = await request(app.getHttpServer())
-        .delete("/tag/1")
+        .delete("/tags/1")
         .expect(200);
       expect(response.body).toHaveProperty("message");
       expect(response.body.message).toContain("1");
     });
 
     it("should call tagDb.deleteTag with the correct id", async () => {
-      await request(app.getHttpServer()).delete("/tag/1");
+      await request(app.getHttpServer()).delete("/tags/1");
       expect(tagDb.deleteTag).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).delete("/tag/abc").expect(400);
+      return request(app.getHttpServer()).delete("/tags/abc").expect(400);
     });
   });
 });
@@ -436,11 +436,11 @@ describe("ProductionController (e2e)", () => {
     await app.close();
   });
 
-  // GET /production
-  describe("GET /production", () => {
+  // GET /productions
+  describe("GET /productions", () => {
     it("should return 200 with an array of productions", () => {
       return request(app.getHttpServer())
-        .get("/production")
+        .get("/productions")
         .expect(200)
         .expect([mockProduction]);
     });
@@ -448,33 +448,33 @@ describe("ProductionController (e2e)", () => {
     it("should return 200 with empty array when no productions exist", async () => {
       jest.spyOn(productionDb, "getProductions").mockResolvedValueOnce([]);
       return request(app.getHttpServer())
-        .get("/production")
+        .get("/productions")
         .expect(200)
         .expect([]);
     });
   });
 
-  // GET /production/:productionId
-  describe("GET /production/:productionId", () => {
+  // GET /productions/:productionId
+  describe("GET /productions/:productionId", () => {
     it("should return 200 with the correct production", () => {
       return request(app.getHttpServer())
-        .get("/production/1")
+        .get("/productions/1")
         .expect(200)
         .expect(mockProduction);
     });
 
     it("should call productionDb.getProductionById with the correct id", async () => {
-      await request(app.getHttpServer()).get("/production/1");
+      await request(app.getHttpServer()).get("/productions/1");
       expect(productionDb.getProductionById).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).get("/production/abc").expect(400);
+      return request(app.getHttpServer()).get("/productions/abc").expect(400);
     });
   });
 
-  // POST /production
-  describe("POST /production", () => {
+  // POST /productions
+  describe("POST /productions", () => {
     const createPayload = {
       titel: "New Production",
       ondertitel: "Subtitle",
@@ -485,7 +485,7 @@ describe("ProductionController (e2e)", () => {
 
     it("should return 201 with the created production", () => {
       return request(app.getHttpServer())
-        .post("/production")
+        .post("/productions")
         .send(createPayload)
         .expect(201)
         .expect(mockProduction);
@@ -493,65 +493,24 @@ describe("ProductionController (e2e)", () => {
 
     it("should call productionDb.createProduction with the payload", async () => {
       await request(app.getHttpServer())
-        .post("/production")
+        .post("/productions")
         .send(createPayload);
       expect(productionDb.createProduction).toHaveBeenCalledWith(createPayload);
     });
 
     it("should return 400 when required fields are missing", () => {
       return request(app.getHttpServer())
-        .post("/production")
+        .post("/productions")
         .send({ titel: "Incomplete" })
         .expect(400);
     });
   });
 
-  // POST /production/insert
-  describe("POST /production/insert", () => {
-    it("should return 201 with the inserted production", () => {
-      // Note: NestJS @Post() defaults to 201 Created.
-      // If you added @HttpCode(200) to your controller, change this to .expect(200)
-      return request(app.getHttpServer())
-        .post("/production/insert")
-        .send(mockProduction)
-        .expect(201)
-        .expect(mockProduction); // Assuming your mock is set up to return the payload
-    });
-
-    it("should call productionDb.insertProduction with the payload", async () => {
-      await request(app.getHttpServer())
-        .post("/production/insert")
-        .send(mockProduction);
-
-      // Verify the right DB method was triggered
-      expect(productionDb.upsertProduction).toHaveBeenCalledWith(
-        mockProduction,
-      );
-    });
-
-    it("should return 400 when the required 'id' is missing", () => {
-      // Destructure to easily create a payload without the ID
-      const { id, ...payloadWithoutId } = mockProduction;
-
-      return request(app.getHttpServer())
-        .post("/production/insert")
-        .send(payloadWithoutId)
-        .expect(400); // Zod should block this
-    });
-
-    it("should return 400 when other required fields are missing", () => {
-      return request(app.getHttpServer())
-        .post("/production/insert")
-        .send({ id: 999, titel: "Incomplete" }) // Has ID, but missing genre, etc.
-        .expect(400); // Zod should also block this
-    });
-  });
-
-  // PUT /production/:productionId
-  describe("PUT /production/:productionId", () => {
+  // PUT /productions/:productionId
+  describe("PUT /productions/:productionId", () => {
     it("should return 200 with the replaced production when ids match", () => {
       return request(app.getHttpServer())
-        .put("/production/1")
+        .put("/productions/1")
         .send(mockProduction)
         .expect(200)
         .expect(mockProduction);
@@ -559,24 +518,24 @@ describe("ProductionController (e2e)", () => {
 
     it("should return 400 when URL id and body id do not match", () => {
       return request(app.getHttpServer())
-        .put("/production/2")
+        .put("/productions/2")
         .send(mockProduction) // id: 1 in body
         .expect(400);
     });
 
     it("should return 400 when id is not a number", () => {
       return request(app.getHttpServer())
-        .put("/production/abc")
+        .put("/productions/abc")
         .send(mockProduction)
         .expect(400);
     });
   });
 
-  // PATCH /production/:productionId
-  describe("PATCH /production/:productionId", () => {
+  // PATCH /productions/:productionId
+  describe("PATCH /productions/:productionId", () => {
     it("should return 200 with the modified production", () => {
       return request(app.getHttpServer())
-        .patch("/production/1")
+        .patch("/productions/1")
         .send({ titel: "Patched titel" })
         .expect(200)
         .expect(mockProduction);
@@ -584,32 +543,32 @@ describe("ProductionController (e2e)", () => {
 
     it("should call productionDb.updateProduction", async () => {
       await request(app.getHttpServer())
-        .patch("/production/1")
+        .patch("/productions/1")
         .send({ titel: "Patched titel" });
       expect(productionDb.updateProduction).toHaveBeenCalled();
     });
 
     it("should return 400 when id is not a number", () => {
       return request(app.getHttpServer())
-        .patch("/production/abc")
+        .patch("/productions/abc")
         .send({ titel: "Patched" })
         .expect(400);
     });
   });
 
-  // DELETE /production/:productionId
-  describe("DELETE /production/:productionId", () => {
+  // DELETE /productions/:productionId
+  describe("DELETE /productions/:productionId", () => {
     it("should return 200 when production is deleted", () => {
-      return request(app.getHttpServer()).delete("/production/1").expect(200);
+      return request(app.getHttpServer()).delete("/productions/1").expect(200);
     });
 
     it("should call productionDb.deleteProduction with the correct id", async () => {
-      await request(app.getHttpServer()).delete("/production/1");
+      await request(app.getHttpServer()).delete("/productions/1");
       expect(productionDb.deleteProduction).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).delete("/production/abc").expect(400);
+      return request(app.getHttpServer()).delete("/productions/abc").expect(400);
     });
   });
 });
@@ -633,71 +592,71 @@ describe("ProductionBlogController (e2e)", () => {
     await app.close();
   });
 
-  // GET /production/:productionId/blog
-  describe("GET /production/:productionId/blog", () => {
+  // GET /productions/:productionId/blogs
+  describe("GET /productions/:productionId/blogs", () => {
     it("should return 200 with blogs linked to the production", () => {
       return request(app.getHttpServer())
-        .get("/production/1/blog")
+        .get("/productions/1/blogs")
         .expect(200)
         .expect([mockBlog]);
     });
 
     it("should call productionDb.getBlogsOfProduction with the correct id", async () => {
-      await request(app.getHttpServer()).get("/production/1/blog");
+      await request(app.getHttpServer()).get("/productions/1/blogs");
       expect(productionDb.getBlogsOfProduction).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when productionId is not a number", () => {
       return request(app.getHttpServer())
-        .get("/production/abc/blog")
+        .get("/productions/abc/blogs")
         .expect(400);
     });
   });
 
-  // PUT /production/:productionId/blog/:blogId
-  describe("PUT /production/:productionId/blog/:blogId", () => {
+  // PUT /productions/:productionId/blogs/:blogId
+  describe("PUT /productions/:productionId/blogs/:blogId", () => {
     it("should return 200 with the linked blog", () => {
       return request(app.getHttpServer())
-        .put("/production/1/blog/1")
+        .put("/productions/1/blogs/1")
         .expect(200)
         .expect(mockBlog);
     });
 
     it("should call productionDb.linkBlogWithProductionID with correct ids", async () => {
-      await request(app.getHttpServer()).put("/production/1/blog/2");
+      await request(app.getHttpServer()).put("/productions/1/blogs/2");
       expect(productionDb.linkBlogWithProductionID).toHaveBeenCalledWith(2, 1);
     });
 
     it("should return 400 when productionId is not a number", () => {
       return request(app.getHttpServer())
-        .put("/production/abc/blog/1")
+        .put("/productions/abc/blogs/1")
         .expect(400);
     });
 
     it("should return 400 when blogId is not a number", () => {
       return request(app.getHttpServer())
-        .put("/production/1/blog/abc")
+        .put("/productions/1/blogs/abc")
         .expect(400);
     });
   });
 
-  // DELETE /production/:productionId/blog/:blogId
-  describe("DELETE /production/:productionId/blog/:blogId", () => {
+  // DELETE /productions/:productionId/blogs/:blogId
+  describe("DELETE /productions/:productionId/blogs/:blogId", () => {
     it("should return 200 with the production after unlinking", () => {
       return request(app.getHttpServer())
-        .delete("/production/1/blog/1")
+        .delete("/productions/1/blogs/1")
         .expect(200)
         .expect(mockProduction);
     });
 
     it("should call productionDb.deleteBlogFromProduction with correct ids", async () => {
-      await request(app.getHttpServer()).delete("/production/1/blog/2");
+      await request(app.getHttpServer()).delete("/productions/1/blogs/2");
       expect(productionDb.deleteBlogFromProduction).toHaveBeenCalledWith(1, 2);
     });
 
     it("should return 400 when productionId is not a number", () => {
       return request(app.getHttpServer())
-        .delete("/production/abc/blog/1")
+        .delete("/productions/abc/blogs/1")
         .expect(400);
     });
   });
@@ -720,71 +679,71 @@ describe("ProductionTagController (e2e)", () => {
     await app.close();
   });
 
-  // GET /production/:productionId/tag
-  describe("GET /production/:productionId/tag", () => {
+  // GET /productions/:productionId/tags
+  describe("GET /productions/:productionId/tags", () => {
     it("should return 200 with tags linked to the production", () => {
       return request(app.getHttpServer())
-        .get("/production/1/tag")
+        .get("/productions/1/tags")
         .expect(200)
         .expect([mockTag]);
     });
 
     it("should call productionDb.getTagsOfProduction", async () => {
-      await request(app.getHttpServer()).get("/production/1/tag");
+      await request(app.getHttpServer()).get("/productions/1/tags");
       expect(productionDb.getTagsOfProduction).toHaveBeenCalled();
     });
 
     it("should return 400 when productionId is not a number", () => {
       return request(app.getHttpServer())
-        .get("/production/abc/tag")
+        .get("/productions/abc/tags")
         .expect(400);
     });
   });
 
-  // PUT /production/:productionId/tag/:tagId
-  describe("PUT /production/:productionId/tag/:tagId", () => {
+  // PUT /productions/:productionId/tags/:tagId
+  describe("PUT /productions/:productionId/tags/:tagId", () => {
     it("should return 200 with the production after adding tag", () => {
       return request(app.getHttpServer())
-        .put("/production/1/tag/1")
+        .put("/productions/1/tags/1")
         .expect(200)
         .expect(mockProduction);
     });
 
     it("should call productionDb.addTagToProduction with correct ids", async () => {
-      await request(app.getHttpServer()).put("/production/1/tag/2");
+      await request(app.getHttpServer()).put("/productions/1/tags/2");
       expect(productionDb.addTagToProduction).toHaveBeenCalledWith(2, 1);
     });
 
     it("should return 400 when productionId is not a number", () => {
       return request(app.getHttpServer())
-        .put("/production/abc/tag/1")
+        .put("/productions/abc/tags/1")
         .expect(400);
     });
 
     it("should return 400 when tagId is not a number", () => {
       return request(app.getHttpServer())
-        .put("/production/1/tag/abc")
+        .put("/productions/1/tags/abc")
         .expect(400);
     });
   });
 
-  // DELETE /production/:productionId/tag/:tagId
-  describe("DELETE /production/:productionId/tag/:tagId", () => {
+  // DELETE /productions/:productionId/tags/:tagId
+  describe("DELETE /productions/:productionId/tags/:tagId", () => {
     it("should return 200 with the production after removing tag", () => {
       return request(app.getHttpServer())
-        .delete("/production/1/tag/1")
+        .delete("/productions/1/tags/1")
         .expect(200)
         .expect(mockProduction);
     });
 
     it("should call productionDb.removeTagFromProduction with correct ids", async () => {
-      await request(app.getHttpServer()).delete("/production/1/tag/2");
+      await request(app.getHttpServer()).delete("/productions/1/tags/2");
       expect(productionDb.removeTagFromProduction).toHaveBeenCalledWith(2, 1);
     });
 
     it("should return 400 when productionId is not a number", () => {
       return request(app.getHttpServer())
-        .delete("/production/abc/tag/1")
+        .delete("/productions/abc/tags/1")
         .expect(400);
     });
   });
@@ -805,42 +764,42 @@ describe("EventController (e2e)", () => {
     await app.close();
   });
 
-  // GET /event
-  describe("GET /event", () => {
+  // GET /events
+  describe("GET /events", () => {
     it("should return 200 with an array of events", () => {
       return request(app.getHttpServer())
-        .get("/event")
+        .get("/events")
         .expect(200)
         .expect([mockEvent]);
     });
 
     it("should return 200 with empty array when no events exist", async () => {
       jest.spyOn(eventDb, "getEvents").mockResolvedValueOnce([]);
-      return request(app.getHttpServer()).get("/event").expect(200).expect([]);
+      return request(app.getHttpServer()).get("/events").expect(200).expect([]);
     });
   });
 
-  // GET /event/:id
-  describe("GET /event/:id", () => {
+  // GET /events/:id
+  describe("GET /events/:id", () => {
     it("should return 200 with the correct event", () => {
       return request(app.getHttpServer())
-        .get("/event/1")
+        .get("/events/1")
         .expect(200)
         .expect(mockEvent);
     });
 
     it("should call eventDb.getEventById with the correct id", async () => {
-      await request(app.getHttpServer()).get("/event/1");
+      await request(app.getHttpServer()).get("/events/1");
       expect(eventDb.getEventById).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).get("/event/abc").expect(400);
+      return request(app.getHttpServer()).get("/events/abc").expect(400);
     });
   });
 
-  // POST /event
-  describe("POST /event", () => {
+  // POST /events
+  describe("POST /events", () => {
     const createPayload = {
       starttime: "2025-06-01T19:00:00.000Z",
       endtime: "2025-06-01T22:00:00.000Z",
@@ -850,23 +809,23 @@ describe("EventController (e2e)", () => {
 
     it("should return 201 with the created event", () => {
       return request(app.getHttpServer())
-        .post("/event")
+        .post("/events")
         .send(createPayload)
         .expect(201)
         .expect(mockEvent);
     });
 
     it("should call eventDb.createEvent with the payload", async () => {
-      await request(app.getHttpServer()).post("/event").send(createPayload);
+      await request(app.getHttpServer()).post("/events").send(createPayload);
       expect(eventDb.createEvent).toHaveBeenCalledWith(createPayload);
     });
   });
 
-  // PUT /event/:id
-  describe("PUT /event/:id", () => {
+  // PUT /events/:id
+  describe("PUT /events/:id", () => {
     it("should return 200 with the replaced event when ids match", () => {
       return request(app.getHttpServer())
-        .put("/event/1")
+        .put("/events/1")
         .send(mockEvent)
         .expect(200)
         .expect(mockEvent);
@@ -874,24 +833,24 @@ describe("EventController (e2e)", () => {
 
     it("should return 400 when URL id and body id do not match", () => {
       return request(app.getHttpServer())
-        .put("/event/2")
+        .put("/events/2")
         .send(mockEvent) // id: 1 in body
         .expect(400);
     });
 
     it("should return 400 when id is not a number", () => {
       return request(app.getHttpServer())
-        .put("/event/abc")
+        .put("/events/abc")
         .send(mockEvent)
         .expect(400);
     });
   });
 
-  // PATCH /event/:id
-  describe("PATCH /event/:id", () => {
+  // PATCH /events/:id
+  describe("PATCH /events/:id", () => {
     it("should return 200 with the modified event", () => {
       return request(app.getHttpServer())
-        .patch("/event/1")
+        .patch("/events/1")
         .send({ price: 25.5 })
         .expect(200)
         .expect(mockEvent);
@@ -899,7 +858,7 @@ describe("EventController (e2e)", () => {
 
     it("should call eventDb.updateEvent", async () => {
       await request(app.getHttpServer())
-        .patch("/event/1")
+        .patch("/events/1")
         .send({ price: 25.5 });
       // Assuming your service calls updateEvent for modifications
       expect(eventDb.updateEvent).toHaveBeenCalled();
@@ -907,25 +866,25 @@ describe("EventController (e2e)", () => {
 
     it("should return 400 when id is not a number", () => {
       return request(app.getHttpServer())
-        .patch("/event/abc")
+        .patch("/events/abc")
         .send({ price: 25.5 })
         .expect(400);
     });
   });
 
-  // DELETE /event/:id
-  describe("DELETE /event/:id", () => {
+  // DELETE /events/:id
+  describe("DELETE /events/:id", () => {
     it("should return 200 when event is deleted", () => {
-      return request(app.getHttpServer()).delete("/event/1").expect(200);
+      return request(app.getHttpServer()).delete("/events/1").expect(200);
     });
 
     it("should call eventDb.deleteEvent with the correct id", async () => {
-      await request(app.getHttpServer()).delete("/event/1");
+      await request(app.getHttpServer()).delete("/events/1");
       expect(eventDb.deleteEvent).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when id is not a number", () => {
-      return request(app.getHttpServer()).delete("/event/abc").expect(400);
+      return request(app.getHttpServer()).delete("/events/abc").expect(400);
     });
   });
 
@@ -944,63 +903,63 @@ describe("EventController (e2e)", () => {
       await app.close();
     });
 
-    // GET /location
-    describe("GET /location", () => {
+    // GET /locations
+    describe("GET /locations", () => {
       it("should return 200 with an array of locations", () => {
         return request(app.getHttpServer())
-          .get("/location")
+          .get("/locations")
           .expect(200)
           .expect([mockLocation]);
       });
     });
 
-    // GET /location/:locationId
-    describe("GET /location/:locationId", () => {
+    // GET /locations/:locationId
+    describe("GET /locations/:locationId", () => {
       it("should return 200 with the correct location", () => {
         return request(app.getHttpServer())
-          .get("/location/1")
+          .get("/locations/1")
           .expect(200)
           .expect(mockLocation);
       });
 
       it("should return 400 when locationId is not a number", () => {
-        return request(app.getHttpServer()).get("/location/abc").expect(400);
+        return request(app.getHttpServer()).get("/locations/abc").expect(400);
       });
     });
 
-    // POST /location
-    describe("POST /location", () => {
+    // POST /locations
+    describe("POST /locations", () => {
       it("should return 201 with the created location", () => {
         const createPayload = { location: "Side Stage" };
         return request(app.getHttpServer())
-          .post("/location")
+          .post("/locations")
           .send(createPayload)
           .expect(201)
           .expect(mockLocation);
       });
     });
 
-    // PATCH /location
+    // PATCH /locations
     // Note: Your controller uses @Patch() without an ID param, expecting it in the DTO
-    describe("PATCH /location", () => {
+    describe("PATCH /locations", () => {
       it("should return 200 with the updated location", () => {
         const updatePayload = { id: 1, location: "Updated Stage" };
         return request(app.getHttpServer())
-          .patch("/location")
+          .patch("/locations")
           .send(updatePayload)
           .expect(200)
           .expect(mockLocation);
       });
     });
 
-    // DELETE /location/:locationId
-    describe("DELETE /location/:locationId", () => {
+    // DELETE /locations/:locationId
+    describe("DELETE /locations/:locationId", () => {
       it("should return 200 after deleting location", () => {
-        return request(app.getHttpServer()).delete("/location/1").expect(200);
+        return request(app.getHttpServer()).delete("/locations/1").expect(200);
       });
 
       it("should return 400 when locationId is not a number", () => {
-        return request(app.getHttpServer()).delete("/location/abc").expect(400);
+        return request(app.getHttpServer()).delete("/locations/abc").expect(400);
       });
     });
   });
@@ -1020,69 +979,69 @@ describe("EventController (e2e)", () => {
       await app.close();
     });
 
-    // GET /event/:eventId/location
-    describe("GET /event/:eventId/location", () => {
+    // GET /events/:eventId/locations
+    describe("GET /events/:eventId/locations", () => {
       it("should return 200 with the location of the event", () => {
         return request(app.getHttpServer())
-          .get("/event/1/location")
+          .get("/events/1/locations")
           .expect(200)
           .expect(mockLocation);
       });
 
       it("should call eventDb.getLocationOfEvent with the correct id", async () => {
-        await request(app.getHttpServer()).get("/event/1/location");
+        await request(app.getHttpServer()).get("/events/1/locations");
         expect(eventDb.getLocationOfEvent).toHaveBeenCalledWith(1);
       });
 
       it("should return 400 when eventId is not a number", () => {
         return request(app.getHttpServer())
-          .get("/event/abc/location")
+          .get("/events/abc/locations")
           .expect(400);
       });
     });
 
-    // PUT /event/:eventId/location/:locationId
-    describe("PUT /event/:eventId/location/:locationId", () => {
+    // PUT /events/:eventId/locations/:locationId
+    describe("PUT /events/:eventId/locations/:locationId", () => {
       it("should return 200 after successfully linking", () => {
         return request(app.getHttpServer())
-          .put("/event/1/location/2")
+          .put("/events/1/locations/2")
           .expect(200);
       });
 
       it("should call eventDb.linkEventToLocation with correct ids", async () => {
-        await request(app.getHttpServer()).put("/event/1/location/2");
+        await request(app.getHttpServer()).put("/events/1/locations/2");
         expect(eventDb.linkEventToLocation).toHaveBeenCalledWith(1, 2);
       });
 
       it("should return 400 when eventId is not a number", () => {
         return request(app.getHttpServer())
-          .put("/event/abc/location/1")
+          .put("/events/abc/locations/1")
           .expect(400);
       });
 
       it("should return 400 when locationId is not a number", () => {
         return request(app.getHttpServer())
-          .put("/event/1/location/abc")
+          .put("/events/1/locations/abc")
           .expect(400);
       });
     });
 
-    // DELETE /event/:eventId/location
-    describe("DELETE /event/:eventId/location", () => {
+    // DELETE /events/:eventId/locations
+    describe("DELETE /events/:eventId/locations", () => {
       it("should return 200 after unlinking", () => {
         return request(app.getHttpServer())
-          .delete("/event/1/location")
+          .delete("/events/1/locations")
           .expect(200);
       });
 
       it("should call eventDb.deleteLocationFromEvent with the eventId", async () => {
-        await request(app.getHttpServer()).delete("/event/1/location");
+        await request(app.getHttpServer()).delete("/events/1/locations");
         expect(eventDb.deleteLocationFromEvent).toHaveBeenCalledWith(1);
       });
 
       it("should return 400 when eventId is not a number", () => {
         return request(app.getHttpServer())
-          .delete("/event/abc/location")
+          .delete("/events/abc/locations")
           .expect(400);
       });
     });

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -524,7 +524,7 @@ describe("ProductionController (e2e)", () => {
         .send(mockProduction);
 
       // Verify the right DB method was triggered
-      expect(productionDb.insertProduction).toHaveBeenCalledWith(
+      expect(productionDb.upsertProduction).toHaveBeenCalledWith(
         mockProduction,
       );
     });


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] This PR refactors existing features.
* All endpoint names have been changed to be in plural form. eg. `event` -> `events` etc...
* INSERT has been merged with PUT to `/productions/:productionId`.

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code

## 🔍 HOW TO TEST

Just look at Swagger API doc names.

## ✅ CLOSED ISSUES
- Closes #129 
- Closes #128 
