### PR TITLE
Init workflow for posting pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,50 @@
+name: Deploy Documentation # This will officially update the main documentation.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest # This doesn't use that much time to build so should not be a problem.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install Dependencies
+        run: pip install mkdocs-material mike
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy with Mike
+        run: |
+          # Get the current branch name (either 'main' or 'develop')
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          
+          if [ "$BRANCH_NAME" == "main" ]; then
+            # Deploy main, tag it as 'latest', and make it the default landing page
+            mike deploy main latest --push --update-aliases
+            mike set-default latest --push
+          else
+            # Deploy develop as its own version
+            mike deploy develop --push
+          fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,6 +20,11 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Create env files
         run: |
           write_env() {

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -62,22 +62,22 @@ jobs:
           
           # Sync files
           rsync -av --delete --exclude 'node_modules' --exclude '.git' . $PR_PATH/
+
+          # Upload the docs
+          cd $PR_PATH
+          python3 -m pip install mkdocs-material
+          python3 -m mkdocs build
+
+          mkdir -p frontend/public
+          rm -rf frontend/public/docs
+          mv site frontend/public/docs
           
+          # Now build Nuxt
           cd $PR_PATH/frontend
           
           # Install & build frontend
           npm install
           npm run build
-
-          cd $PR_PATH
-
-          python3 -m pip install mkdocs-material
-
-          python3 -m mkdocs build
-
-          mv site frontend/.output/public/docs
-
-          cd $PR_PATH/frontend
           
           # Stop old preview if running
           pm2 delete preview-$PR || true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -63,6 +63,16 @@ jobs:
           # Install & build frontend
           npm install
           npm run build
+
+          cd $PR_PATH
+
+          python3 -m pip install mkdocs-material
+
+          python3 -m mkdocs build
+
+          mv site frontend/.output/public/docs
+
+          cd $PR_PATH/frontend
           
           # Stop old preview if running
           pm2 delete preview-$PR || true
@@ -77,6 +87,7 @@ jobs:
         with:
           message: |
             🚀 **Preview Build succesfully deployed!**
-            You can view the preview of this pull request at:
-            http://sel2-4.ugent.be/previews/${{ github.event.pull_request.number }}/
+
+            📱 **Website Preview:** http://sel2-4.ugent.be/previews/${{ github.event.pull_request.number }}/
+            📚 **Docs Preview:** http://sel2-4.ugent.be/previews/${{ github.event.pull_request.number }}/docs/
           comment_tag: preview_link

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Welcome to MkDocs
+
+For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+
+## Commands
+
+* `mkdocs new [dir-name]` - Create a new project.
+* `mkdocs serve` - Start the live-reloading docs server.
+* `mkdocs build` - Build the documentation site.
+* `mkdocs -h` - Print help message and exit.
+
+## Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,3 +3,4 @@ site_name: My Docs
 extra:
   version:
     provider: mike
+theme: readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: My Docs
+
+extra:
+  version:
+    provider: mike

--- a/package-lock.json
+++ b/package-lock.json
@@ -3572,18 +3572,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@nuxt/cli/node_modules/giget": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/giget/-/giget-3.1.2.tgz",
@@ -10636,23 +10624,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crossws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
-      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.7.1"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
       }
     },
     "node_modules/css-declaration-sorter": {


### PR DESCRIPTION
## 🎯 MAIN GOAL

Adds workflows and files for documentation of the Project.

Docs for PRs should be served on the `/docs` path of the PR-preview. See the Github Actions bot comment below.
When a PUSH happens to either develop or main the pages should be pushed to the global pages of the project. (We will have to test this when the PR is merged.)

## 🛠️ TESTING

N/A

## 📝 DOCUMENTATION

N/A

## ✅ CLOSED ISSUES
- Closes #151 
