### PR TITLE
add documentation for testing

### DIFF
--- a/docs/testing/backend.md
+++ b/docs/testing/backend.md
@@ -32,6 +32,8 @@ cd backend
 npm run test:coverage
 ```
 
+To exclude a file or directory from the coverage, add it to the `coveragePathIgnorePatterns` list in `backend/jest.config.ts`
+
 ## Tips
 
 - Use `npm run test:watch` during development for auto-rerun on file changes.

--- a/docs/testing/backend.md
+++ b/docs/testing/backend.md
@@ -8,7 +8,7 @@ From the repository root:
 
 ```bash
 cd backend
-npm install           # ensure dependencies are installed
+npm install           # or `npm i`
 npm run test          # runs Jest unit tests
 ```
 

--- a/docs/testing/backend.md
+++ b/docs/testing/backend.md
@@ -2,7 +2,7 @@
 
 This section covers how to run and interpret tests for the backend (NestJS) project.
 
-## Running unit tests
+## Running tests
 
 From the repository root:
 

--- a/docs/testing/backend.md
+++ b/docs/testing/backend.md
@@ -1,0 +1,38 @@
+# Backend Testing
+
+This section covers how to run and interpret tests for the backend (NestJS) project.
+
+## Running unit tests
+
+From the repository root:
+
+```bash
+cd backend
+npm install           # ensure dependencies are installed
+npm run test          # runs Jest unit tests
+```
+
+## Running end‑to‑end tests
+
+```bash
+cd backend
+npm run test:e2e     # execute integration/e2e tests
+```
+
+## Coverage reports
+
+The Jest run generates a coverage report in `backend/coverage`. Open `backend/coverage/lcov-report/index.html` in a browser to view.
+
+The repo also tracks coverage output under `coverage/` at the project root.
+
+You can also check the coverage by running:
+
+```bash
+cd backend
+npm run test:coverage
+```
+
+## Tips
+
+- Use `npm run test:watch` during development for auto-rerun on file changes.
+- Tests are located alongside their implementation (`*.spec.ts`) in each module.

--- a/docs/testing/frontend.md
+++ b/docs/testing/frontend.md
@@ -6,7 +6,7 @@ This section describes how to run and review tests for the Nuxt/Vue frontend.
 
 ```bash
 cd frontend
-npm install
+npm install     # or `npm i`
 npm run test    # vitest configured via `vitest.config.ts`
 ```
 

--- a/docs/testing/frontend.md
+++ b/docs/testing/frontend.md
@@ -25,6 +25,8 @@ npm run test:coverage
 
 and view the HTML report under `frontend/coverage`.
 
+To exclude a file or directory from the coverage, add it to the `coverage.exclude` list in `frontend/vitest.config.ts`
+
 ## General notes
 
 * The `frontend/package.json` defines several helpful scripts (`dev`, `build`, `preview`, etc.).

--- a/docs/testing/frontend.md
+++ b/docs/testing/frontend.md
@@ -1,0 +1,31 @@
+# Frontend Testing
+
+This section describes how to run and review tests for the Nuxt/Vue frontend.
+
+## Running tests
+
+```bash
+cd frontend
+npm install
+npm run test    # vitest configured via `vitest.config.ts`
+```
+
+## Running end‑to‑end tests (if available)
+
+The front-end does not currently include e2e tests.
+
+## Coverage
+
+Vitest outputs coverage if you enable it in `vitest.config.ts` (already configured for `frontend`).  
+Run:
+
+```bash
+npm run test:coverage
+```
+
+and view the HTML report under `frontend/coverage`.
+
+## General notes
+
+* The `frontend/package.json` defines several helpful scripts (`dev`, `build`, `preview`, etc.).
+* To see live feedback while editing components, run `npm run dev` and open the browser.

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -1,0 +1,45 @@
+# Testing Overview
+
+This project uses different testing frameworks for each package within the monorepo. This section guides you through running tests across the entire project or focusing on specific packages.
+
+## Running All Tests
+
+From the repository root, run tests across all packages:
+
+```bash
+npm run test
+```
+
+For coverage reports across all packages:
+
+```bash
+npm run test:coverage
+```
+
+## Backend Testing
+
+The backend (NestJS) uses **Jest** as the testing framework.
+
+- **Unit Tests**: Run `npm run test` in the `backend/` folder
+- **End-to-End Tests**: Run `npm run test:e2e` to test API integration
+- **Coverage Reports**: Available in `backend/coverage/lcov-report/`
+
+For detailed instructions, see [Backend Testing](backend.md).
+
+## Frontend Testing
+
+The frontend (Nuxt + Vue) uses **Vitest** for unit testing.
+
+- **Unit Tests**: Run `npm run test` in the `frontend/` folder
+- **Coverage Reports**: Available in `frontend/coverage/`
+
+For detailed instructions, see [Frontend Testing](frontend.md).
+
+## Coverage Reports
+
+After running tests with coverage, HTML reports are generated:
+
+- **Backend**: `backend/coverage/lcov-report/index.html`
+- **Frontend**: `frontend/coverage/lcov-report/index.html`
+
+Open these in a browser to view detailed coverage metrics.

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -43,3 +43,10 @@ After running tests with coverage, HTML reports are generated:
 - **Frontend**: `frontend/coverage/lcov-report/index.html`
 
 Open these in a browser to view detailed coverage metrics.
+
+Some code is exlcuded from the coverage due to some files not needing tests (database queries, modules, main, etc.)
+
+To remove a file from coverage, put them in the corresponding files:
+
+- **Backend**: `backend/jest.config.ts`, add path to list `coveragePathIgnorePatterns`
+- **Frontend**: `frontend/vitest.config.ts`, add path to list `coverage.exclude`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,5 +8,6 @@ theme: readthedocs
 nav:
   - Home: index.md
   - Testing:
+      - Overview: testing/index.md
       - Backend: testing/backend.md
       - Frontend: testing/frontend.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,3 +4,9 @@ extra:
   version:
     provider: mike
 theme: readthedocs
+
+nav:
+  - Home: index.md
+  - Testing:
+      - Backend: testing/backend.md
+      - Frontend: testing/frontend.md


### PR DESCRIPTION
## 🎯 MAIN GOAL
Add documentation for testing on mkdocs pages

## 🛠️ TESTING
N/A

## 📝 DOCUMENTATION
N/A

## 🔍 HOW TO TEST
1. install mkdocs if you haven't
2. run `mkdocs serve`
3. browse to http://127.0.0.1:8000 and check the docs

You can also check the generated preview by github actions below (once the tests pass)

## ✅ CLOSED ISSUES
- Closes #156
