### PR TITLE
Refactor endpoints

### DIFF
--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -65,9 +65,9 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer()).delete("/events/1").expect(401);
     });
 
-    it("GET /events/:eventId/locations", async () => {
+    it("GET /events/:eventId/location", async () => {
       await request(app.getHttpServer())
-        .get("/events/1/locations")
+        .get("/events/1/location")
         .expect((res) => {
           expect([200, 410]).toContain(res.status);
         });
@@ -75,9 +75,9 @@ describe("AuthGuards tests", () => {
   });
 
   describe("Event - Location endpoints authentication", () => {
-    it("GET /events/:eventId/locations should work without API key", async () => {
+    it("GET /events/:eventId/location should work without API key", async () => {
       await request(app.getHttpServer())
-        .get("/events/1/locations")
+        .get("/events/1/location")
         .expect((res) => {
           expect([200, 410]).toContain(res.status);
         });

--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -56,25 +56,25 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer()).delete("/events/1").expect(401);
     });
 
-    it("GET /events/:eventId/locations", async () => {
-      await request(app.getHttpServer()).get("/events/1/locations").expect(200);
+    it("GET /events/:eventId/location", async () => {
+      await request(app.getHttpServer()).get("/events/1/location").expect(200);
     });
   });
 
   describe("Event - Location endpoints authentication", () => {
-    it("GET /events/:eventId/locations should work without API key", async () => {
-      await request(app.getHttpServer()).get("/events/1/locations").expect(200);
+    it("GET /events/:eventId/location should work without API key", async () => {
+      await request(app.getHttpServer()).get("/events/1/location").expect(200);
     });
 
-    it("PUT /events/:eventId/locations/:locationId should fail without API key.", async () => {
+    it("PUT /events/:eventId/location/:locationId should fail without API key.", async () => {
       await request(app.getHttpServer())
-        .put("/events/1/locations/1")
+        .put("/events/1/location/1")
         .expect(401);
     });
 
     it("DELETE /events/:eventId/locations should fail without API key.", async () => {
       await request(app.getHttpServer())
-        .delete("/events/1/locations")
+        .delete("/events/1/location")
         .expect(401);
     });
   });

--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -41,7 +41,10 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /events/:id should work without API key", async () => {
-      await request(app.getHttpServer()).get("/events/1").send({}).expect(200);
+      const response = await request(app.getHttpServer())
+        .get("/events/1")
+        .send({});
+      expect([200, 410]).toContain(response.status);
     });
 
     it("POST /events should fail without API key", async () => {
@@ -55,15 +58,14 @@ describe("AuthGuards tests", () => {
     it("DELETE /events/:id should fail without API key", async () => {
       await request(app.getHttpServer()).delete("/events/1").expect(401);
     });
-
-    it("GET /events/:eventId/location", async () => {
-      await request(app.getHttpServer()).get("/events/1/location").expect(200);
-    });
   });
 
   describe("Event - Location endpoints authentication", () => {
     it("GET /events/:eventId/location should work without API key", async () => {
-      await request(app.getHttpServer()).get("/events/1/location").expect(200);
+      const response = await request(app.getHttpServer()).get(
+        "/events/1/location",
+      );
+      expect([200, 410]).toContain(response.status);
     });
 
     it("PUT /events/:eventId/location/:locationId should fail without API key.", async () => {
@@ -81,7 +83,10 @@ describe("AuthGuards tests", () => {
 
   describe("Event - Price endpoints authentication", () => {
     it("GET /events/:eventId/prices should work without API key", async () => {
-      await request(app.getHttpServer()).get("/events/1/prices").expect(200);
+      const response = await request(app.getHttpServer()).get(
+        "/events/1/prices",
+      );
+      expect([200, 410]).toContain(response.status);
     });
 
     it("PUT /events/:eventId/prices/:priceId should fail without API key.", async () => {
@@ -101,10 +106,10 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /productions/:id should work without API key", async () => {
-      await request(app.getHttpServer())
+      const response = await request(app.getHttpServer())
         .get("/productions/1")
-        .send({})
-        .expect(200);
+        .send({});
+      expect([200, 410]).toContain(response.status);
     });
 
     it("POST /productions should fail without API key", async () => {
@@ -132,9 +137,10 @@ describe("AuthGuards tests", () => {
 
   describe("Production-blog endpoints authentication", () => {
     it("GET /productions/:id/blogs should work without API key", async () => {
-      await request(app.getHttpServer())
-        .get("/productions/1/blogs")
-        .expect(200);
+      const response = await request(app.getHttpServer()).get(
+        "/productions/1/blogs",
+      );
+      expect([200, 410]).toContain(response.status);
     });
 
     it("PUT /productions/:id/blogs/:id should fail without API key", async () => {
@@ -153,7 +159,10 @@ describe("AuthGuards tests", () => {
 
   describe("Production-tag endpoints authentication", () => {
     it("GET /productions/:id/tags should work without API key", async () => {
-      await request(app.getHttpServer()).get("/productions/1/tags").expect(200);
+      const response = await request(app.getHttpServer()).get(
+        "/productions/1/tags",
+      );
+      expect([200, 410]).toContain(response.status);
     });
 
     it("PUT /productions/:id/tags/:id should fail without API key", async () => {
@@ -180,7 +189,10 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /tags/:id should work without API key", async () => {
-      await request(app.getHttpServer()).get("/tags/1").send({}).expect(200);
+      const response = await request(app.getHttpServer())
+        .get("/tags/1")
+        .send({});
+      expect([200, 410]).toContain(response.status);
     });
 
     it("DELETE /tags/:id should fail without API key", async () => {
@@ -202,7 +214,10 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /blogs/:id should work without API key", async () => {
-      await request(app.getHttpServer()).get("/blogs/1").send({}).expect(200);
+      const response = await request(app.getHttpServer())
+        .get("/blogs/1")
+        .send({});
+      expect([200, 410]).toContain(response.status);
     });
 
     it("DELETE /blogs/:id should fail without API key", async () => {
@@ -224,7 +239,8 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /locations/:locationId should work without API key", async () => {
-      await request(app.getHttpServer()).get("/locations/1").expect(200);
+      const response = await request(app.getHttpServer()).get("/locations/1");
+      expect([200, 410]).toContain(response.status);
     });
 
     it("POST /locations should fail without API key", async () => {
@@ -246,7 +262,8 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /prices/:priceId should work without API key.", async () => {
-      await request(app.getHttpServer()).get("/prices/2").expect(200);
+      const response = await request(app.getHttpServer()).get("/prices/2");
+      expect([200, 410]).toContain(response.status);
     });
 
     it("POST /prices should fail without API key.", async () => {

--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -253,8 +253,8 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer()).post("/prices").expect(401);
     });
 
-    it("PUT /prices should fail without API key.", async () => {
-      await request(app.getHttpServer()).put("/prices").expect(401);
+    it("PATCH /prices/:priceId should fail without API key.", async () => {
+      await request(app.getHttpServer()).patch("/prices/2").expect(401);
     });
 
     it("DELETE /prices/:priceId should fail without API key.", async () => {

--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -72,7 +72,7 @@ describe("AuthGuards tests", () => {
         .expect(401);
     });
 
-    it("DELETE /events/:eventId/locations should fail without API key.", async () => {
+    it("DELETE /events/:eventId/location should fail without API key.", async () => {
       await request(app.getHttpServer())
         .delete("/events/1/location")
         .expect(401);
@@ -231,8 +231,8 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer()).post("/locations").expect(401);
     });
 
-    it("PATCH /locations should fail without API key", async () => {
-      await request(app.getHttpServer()).patch("/locations").expect(401);
+    it("PATCH /locations/:locationId should fail without API key", async () => {
+      await request(app.getHttpServer()).patch("/locations/1").expect(401);
     });
 
     it("DELETE /locations/:locationId should fail without API key", async () => {

--- a/backend/src/blog/blog.service.spec.ts
+++ b/backend/src/blog/blog.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { BadRequestException } from "@nestjs/common";
 import { BlogService } from "./blog.service";
 import { BlogDatabaseService } from "../database/db.blog.service";
 import {
@@ -121,23 +120,7 @@ describe("BlogService", () => {
       const result = await service.replaceBlog(1, replaceDto);
 
       expect(result).toEqual(mockBlog);
-      expect(blogDbService.updateBlog).toHaveBeenCalledWith(replaceDto);
-    });
-
-    it("should throw a BadRequestException when IDs do not match", async () => {
-      const replaceDto: BlogDto = { ...mockBlog, id: 2 }; // ID mismatch here
-
-      // We expect the promise to reject with the specific exception
-      await expect(service.replaceBlog(1, replaceDto)).rejects.toThrow(
-        BadRequestException,
-      );
-
-      await expect(service.replaceBlog(1, replaceDto)).rejects.toThrow(
-        "Blog ID and URL ID do not match. Cannot replace Blog.",
-      );
-
-      // Ensure the database service was never called
-      expect(blogDbService.updateBlog).not.toHaveBeenCalled();
+      expect(blogDbService.updateBlog).toHaveBeenCalledWith(1, replaceDto);
     });
   });
 
@@ -163,13 +146,7 @@ describe("BlogService", () => {
 
       expect(result).toEqual(expectedUpdatedBlog);
       // Validate that the ID was injected into the DTO before calling the DB
-      expect(blogDbService.updateBlog).toHaveBeenCalledWith({
-        id: 1,
-        titel: {
-          en: "Updated titel",
-          nl: "Bijgewerkte titel",
-        },
-      });
+      expect(blogDbService.updateBlog).toHaveBeenCalledWith(1, updateDto);
     });
   });
 

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { BlogDatabaseService } from "../database/db.blog.service";
 import {
   BlogDto,
@@ -51,12 +51,7 @@ export class BlogService {
    * @returns The newly replaced Blog.
    */
   async replaceBlog(id: number, blog: UpdateBlogDto): Promise<BlogDto> {
-    if (blog.id !== id)
-      throw new BadRequestException(
-        "Blog ID and URL ID do not match. Cannot replace Blog.",
-      );
-
-    return await this.blogDbService.updateBlog(blog);
+    return await this.blogDbService.updateBlog(id, blog);
   }
 
   /**
@@ -66,8 +61,7 @@ export class BlogService {
    * @returns The newly modified Blog.
    */
   async modifyBlog(id: number, blog: UpdateBlogDto): Promise<BlogDto> {
-    blog.id = id;
-    return await this.blogDbService.updateBlog(blog);
+    return await this.blogDbService.updateBlog(id, blog);
   }
 
   /**

--- a/backend/src/csv_parsing/csv_file_parser.spec.ts
+++ b/backend/src/csv_parsing/csv_file_parser.spec.ts
@@ -28,243 +28,246 @@ function createMockStream(rows: any[], error?: Error) {
   };
 }
 
-describe("CSVFileParser.parseCSVWithSchema", () => {
-  beforeEach(() => {
-    // silence warnings emitted during parsing; tests will assert on them if needed
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  });
-
-  it("should parse valid rows", async () => {
-    mockedFs.createReadStream.mockReturnValue(
-      createMockStream([
-        { name: "John", age: "30" },
-        { name: "Jane", age: "25" },
-      ]) as any,
-    );
-
-    const schema = z.object({
-      name: z.string(),
-      age: z.number(),
+// TODO: Remove skip
+describe.skip("CSVFileParser", () => {
+  describe("CSVFileParser.parseCSVWithSchema", () => {
+    beforeEach(() => {
+      // silence warnings emitted during parsing; tests will assert on them if needed
+      jest.spyOn(console, "warn").mockImplementation(() => {});
     });
 
-    const result = await CSVFileParser.parseCSVWithSchema(
-      "dummy.csv",
-      schema,
-      (row) => ({
-        name: row.name,
-        age: Number(row.age),
-      }),
-    );
+    afterEach(() => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
 
-    expect(result).toEqual([
-      { name: "John", age: 30 },
-      { name: "Jane", age: 25 },
-    ]);
-  });
+    it("should parse valid rows", async () => {
+      mockedFs.createReadStream.mockReturnValue(
+        createMockStream([
+          { name: "John", age: "30" },
+          { name: "Jane", age: "25" },
+        ]) as any,
+      );
 
-  it("should reject when stream emits error", async () => {
-    mockedFs.createReadStream.mockReturnValue(
-      createMockStream([], new Error("Stream failure")) as any,
-    );
+      const schema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
 
-    await expect(
-      CSVFileParser.parseCSVWithSchema("dummy.csv", z.any(), (row) => row),
-    ).rejects.toThrow("Stream failure");
-  });
-});
+      const result = await CSVFileParser.parseCSVWithSchema(
+        "dummy.csv",
+        schema,
+        (row) => ({
+          name: row.name,
+          age: Number(row.age),
+        }),
+      );
 
-describe("CSVFileParser.transformEventRow", () => {
-  it("should transform a valid row correctly", () => {
-    const row = {
-      Starttime: "2024-01-01 10:00:00",
-      Endtime: "2024-01-01 12:00:00",
-      Production: "5",
-      Genre: "drama",
-      Hall: "Main Hall",
-    };
+      expect(result).toEqual([
+        { name: "John", age: 30 },
+        { name: "Jane", age: 25 },
+      ]);
+    });
 
-    const result = CSVFileParser.transformEventRow(row);
+    it("should reject when stream emits error", async () => {
+      mockedFs.createReadStream.mockReturnValue(
+        createMockStream([], new Error("Stream failure")) as any,
+      );
 
-    expect(result).toEqual({
-      starttime: new Date("2024-01-01 10:00:00").toISOString(),
-      endtime: new Date("2024-01-01 12:00:00").toISOString(),
-      production_id: 5,
-      location: "Main Hall",
-      doors_at: null,
-      intermission_at: null,
-      legacy_id: null,
+      await expect(
+        CSVFileParser.parseCSVWithSchema("dummy.csv", z.any(), (row) => row),
+      ).rejects.toThrow("Stream failure");
     });
   });
 
-  it("should set endtime to null if invalid", () => {
-    const row = {
-      Starttime: "2024-01-01 10:00:00",
-      Endtime: "0000-00-00 00:00:00",
-      Production: "5",
-      Hall: "",
-    };
+  describe("CSVFileParser.transformEventRow", () => {
+    it("should transform a valid row correctly", () => {
+      const row = {
+        Starttime: "2024-01-01 10:00:00",
+        Endtime: "2024-01-01 12:00:00",
+        Production: "5",
+        Genre: "drama",
+        Hall: "Main Hall",
+      };
 
-    const result = CSVFileParser.transformEventRow(row);
+      const result = CSVFileParser.transformEventRow(row);
 
-    expect(result.endtime).toBeNull();
-    expect(result.location).toBe("");
-  });
-
-  it("should throw if starttime is invalid", () => {
-    const row = {
-      Starttime: "invalid-date",
-      Endtime: "",
-      Production: "5",
-    };
-
-    expect(() => CSVFileParser.transformEventRow(row)).toThrow(
-      "Invalid starttime",
-    );
-  });
-
-  it("should throw if production id is invalid", () => {
-    const row = {
-      Starttime: "2024-01-01 10:00:00",
-      Endtime: "",
-      Production: "abc",
-    };
-
-    expect(() => CSVFileParser.transformEventRow(row)).toThrow(
-      "Invalid production id",
-    );
-  });
-});
-
-describe("CSVFileParser.transformProductionRow", () => {
-  it("should transform production row correctly", () => {
-    const row = {
-      ID: "1",
-      Titel: "Hamlet",
-      Ondertitel: "A tragedy",
-      Description1: "Main description",
-      Description2: "",
-      Genre: "drama",
-    };
-
-    const result = CSVFileParser.transformProductionRow(row);
-
-    expect(result).toEqual({
-      titel: { en: "Hamlet", nl: "Hamlet" },
-      description1: { en: "Main description", nl: "Main description" },
-      description2: null,
-      tags: ["drama"],
-      artist: null,
-      tagline: { en: "A tragedy", nl: "A tragedy" },
-      credits: null,
-      performer_type: null,
-      attendance_mode: null,
-      legacy_id: "csv-1",
-    });
-  });
-
-  it("should throw if ID is invalid", () => {
-    const row = {
-      ID: "notanumber",
-      Titel: "Title",
-      Ondertitel: "Sub",
-      Description1: "desc",
-      Description2: "",
-    };
-    expect(() => CSVFileParser.transformProductionRow(row)).toThrow(
-      /Invalid production id/,
-    );
-  });
-});
-
-// additional tests for the convenience wrappers and insertion logic
-
-describe("CSVFileParser.parseEventsCSV", () => {
-  beforeEach(() => {
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-  });
-
-  afterEach(() => jest.clearAllMocks());
-
-  it("should parse and transform event rows, skipping invalid ones", async () => {
-    // include one valid and one invalid row; valid row contains a hall
-    mockedFs.createReadStream.mockReturnValue(
-      createMockStream([
-        {
-          Starttime: "2025-05-01 14:00:00",
-          Endtime: "2025-05-01 15:00:00",
-          Production: "10",
-          Hall: "Front Stage",
-        },
-        {
-          // bad start time will be skipped by transform
-          Starttime: "not-a-date",
-          Endtime: "",
-          Production: "10",
-          Hall: "Backstage",
-        },
-      ]) as any,
-    );
-
-    const items = await CSVFileParser.parseEventsCSV("events.csv");
-    expect(items).toHaveLength(1);
-    expect(items[0]).toEqual({
-      event: {
-        starttime: new Date("2025-05-01 14:00:00").toISOString(),
-        endtime: new Date("2025-05-01 15:00:00").toISOString(),
-        production_id: 10,
+      expect(result).toEqual({
+        starttime: new Date("2024-01-01 10:00:00").toISOString(),
+        endtime: new Date("2024-01-01 12:00:00").toISOString(),
+        production_id: 5,
+        location: "Main Hall",
         doors_at: null,
         intermission_at: null,
         legacy_id: null,
-      },
-      location: "Front Stage",
+      });
     });
 
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining("Skipping invalid row"),
-    );
+    it("should set endtime to null if invalid", () => {
+      const row = {
+        Starttime: "2024-01-01 10:00:00",
+        Endtime: "0000-00-00 00:00:00",
+        Production: "5",
+        Hall: "",
+      };
+
+      const result = CSVFileParser.transformEventRow(row);
+
+      expect(result.endtime).toBeNull();
+      expect(result.location).toBe("");
+    });
+
+    it("should throw if starttime is invalid", () => {
+      const row = {
+        Starttime: "invalid-date",
+        Endtime: "",
+        Production: "5",
+      };
+
+      expect(() => CSVFileParser.transformEventRow(row)).toThrow(
+        "Invalid starttime",
+      );
+    });
+
+    it("should throw if production id is invalid", () => {
+      const row = {
+        Starttime: "2024-01-01 10:00:00",
+        Endtime: "",
+        Production: "abc",
+      };
+
+      expect(() => CSVFileParser.transformEventRow(row)).toThrow(
+        "Invalid production id",
+      );
+    });
   });
-});
 
-describe("CSVFileParser.parseProductionsCSV", () => {
-  afterEach(() => jest.clearAllMocks());
+  describe("CSVFileParser.transformProductionRow", () => {
+    it("should transform production row correctly", () => {
+      const row = {
+        ID: "1",
+        Titel: "Hamlet",
+        Ondertitel: "A tragedy",
+        Description1: "Main description",
+        Description2: "",
+        Genre: "drama",
+      };
 
-  it("should parse production rows and validate against schema", async () => {
-    mockedFs.createReadStream.mockReturnValue(
-      createMockStream([
-        {
-          ID: "2",
-          Titel: "Macbeth",
-          Ondertitel: "",
-          Description1: "desc",
-          Description2: "more",
-          Genre: "tragedy",
+      const result = CSVFileParser.transformProductionRow(row);
+
+      expect(result).toEqual({
+        titel: { en: "Hamlet", nl: "Hamlet" },
+        description1: { en: "Main description", nl: "Main description" },
+        description2: null,
+        tags: ["drama"],
+        artist: null,
+        tagline: { en: "A tragedy", nl: "A tragedy" },
+        credits: null,
+        performer_type: null,
+        attendance_mode: null,
+        legacy_id: "csv-1",
+      });
+    });
+
+    it("should throw if ID is invalid", () => {
+      const row = {
+        ID: "notanumber",
+        Titel: "Title",
+        Ondertitel: "Sub",
+        Description1: "desc",
+        Description2: "",
+      };
+      expect(() => CSVFileParser.transformProductionRow(row)).toThrow(
+        /Invalid production id/,
+      );
+    });
+  });
+
+  // additional tests for the convenience wrappers and insertion logic
+
+  describe("CSVFileParser.parseEventsCSV", () => {
+    beforeEach(() => {
+      jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    it("should parse and transform event rows, skipping invalid ones", async () => {
+      // include one valid and one invalid row; valid row contains a hall
+      mockedFs.createReadStream.mockReturnValue(
+        createMockStream([
+          {
+            Starttime: "2025-05-01 14:00:00",
+            Endtime: "2025-05-01 15:00:00",
+            Production: "10",
+            Hall: "Front Stage",
+          },
+          {
+            // bad start time will be skipped by transform
+            Starttime: "not-a-date",
+            Endtime: "",
+            Production: "10",
+            Hall: "Backstage",
+          },
+        ]) as any,
+      );
+
+      const items = await CSVFileParser.parseEventsCSV("events.csv");
+      expect(items).toHaveLength(1);
+      expect(items[0]).toEqual({
+        event: {
+          starttime: new Date("2025-05-01 14:00:00").toISOString(),
+          endtime: new Date("2025-05-01 15:00:00").toISOString(),
+          production_id: 10,
+          doors_at: null,
+          intermission_at: null,
+          legacy_id: null,
         },
-      ]) as any,
-    );
-    const result = await CSVFileParser.parseProductionsCSV("prods.csv");
-    // since we only provided one row without any comma-separated genres,
-    // we expect a single production, no tags, and no links
-    expect(result).toEqual({
-      productions: [
-        {
-          titel: { en: "Macbeth", nl: "Macbeth" },
-          tagline: null,
-          description1: { en: "desc", nl: "desc" },
-          description2: { en: "more", nl: "more" },
-          artist: null,
-          credits: null,
-          performer_type: null,
-          attendance_mode: null,
-          legacy_id: "csv-2",
-        },
-      ],
-      tags: ["tragedy"],
-      productionTagLinks: [{ legacyId: "csv-2", tagName: "tragedy" }],
+        location: "Front Stage",
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping invalid row"),
+      );
+    });
+  });
+
+  describe("CSVFileParser.parseProductionsCSV", () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it("should parse production rows and validate against schema", async () => {
+      mockedFs.createReadStream.mockReturnValue(
+        createMockStream([
+          {
+            ID: "2",
+            Titel: "Macbeth",
+            Ondertitel: "",
+            Description1: "desc",
+            Description2: "more",
+            Genre: "tragedy",
+          },
+        ]) as any,
+      );
+      const result = await CSVFileParser.parseProductionsCSV("prods.csv");
+      // since we only provided one row without any comma-separated genres,
+      // we expect a single production, no tags, and no links
+      expect(result).toEqual({
+        productions: [
+          {
+            titel: { en: "Macbeth", nl: "Macbeth" },
+            tagline: null,
+            description1: { en: "desc", nl: "desc" },
+            description2: { en: "more", nl: "more" },
+            artist: null,
+            credits: null,
+            performer_type: null,
+            attendance_mode: null,
+            legacy_id: "csv-2",
+          },
+        ],
+        tags: ["tragedy"],
+        productionTagLinks: [{ legacyId: "csv-2", tagName: "tragedy" }],
+      });
     });
   });
 });

--- a/backend/src/csv_parsing/csv_file_parser.spec.ts
+++ b/backend/src/csv_parsing/csv_file_parser.spec.ts
@@ -29,7 +29,7 @@ function createMockStream(rows: any[], error?: Error) {
 }
 
 // TODO: Remove skip
-describe.skip("CSVFileParser", () => {
+describe("CSVFileParser", () => {
   describe("CSVFileParser.parseCSVWithSchema", () => {
     beforeEach(() => {
       // silence warnings emitted during parsing; tests will assert on them if needed
@@ -99,7 +99,6 @@ describe.skip("CSVFileParser", () => {
         location: "Main Hall",
         doors_at: null,
         intermission_at: null,
-        legacy_id: null,
       });
     });
 
@@ -221,7 +220,6 @@ describe.skip("CSVFileParser", () => {
           production_id: 10,
           doors_at: null,
           intermission_at: null,
-          legacy_id: null,
         },
         location: "Front Stage",
       });

--- a/backend/src/csv_parsing/csv_file_parser.spec.ts
+++ b/backend/src/csv_parsing/csv_file_parser.spec.ts
@@ -28,7 +28,6 @@ function createMockStream(rows: any[], error?: Error) {
   };
 }
 
-// TODO: Remove skip
 describe("CSVFileParser", () => {
   describe("CSVFileParser.parseCSVWithSchema", () => {
     beforeEach(() => {

--- a/backend/src/csv_parsing/csv_file_parser.ts
+++ b/backend/src/csv_parsing/csv_file_parser.ts
@@ -8,7 +8,7 @@ import { CreateEventSchema, CreateProductionSchema } from "@repo/common";
  * Type used to structure production import
  */
 type ParsedProductionImport = {
-  productions: CreateProductionDto[];
+  productions: (CreateProductionDto & { legacy_id: string })[];
   tags: string[];
   productionTagLinks: { legacyId: string; tagName: string }[];
 };
@@ -120,13 +120,12 @@ export class CSVFileParser {
       location: location,
       doors_at: null, // TODO
       intermission_at: null, // TODO
-      legacy_id: null,
     };
   }
 
   static transformProductionRow(
     row: Record<string, string>,
-  ): CreateProductionDto & { tags: string[] } {
+  ): CreateProductionDto & { tags: string[]; legacy_id: string } {
     // validate and convert numeric fields manually to provide clearer errors
     const id = Number(row.ID);
     if (isNaN(id)) {
@@ -189,15 +188,18 @@ export class CSVFileParser {
   static async parseProductionsCSV(
     filePath: string,
   ): Promise<ParsedProductionImport> {
-    const productions: CreateProductionDto[] = [];
+    const productions: (CreateProductionDto & { legacy_id: string })[] = [];
     const tagsSet: Set<string> = new Set();
     const productionTagLinks: { legacyId: string; tagName: string }[] = [];
 
     const parsed = await this.parseCSVWithSchema<
-      CreateProductionDto & { tags: string[] }
+      CreateProductionDto & { tags: string[]; legacy_id: string }
     >(
       filePath,
-      CreateProductionSchema.extend({ tags: string().array() }),
+      CreateProductionSchema.extend({
+        tags: string().array(),
+        legacy_id: string(),
+      }),
       this.transformProductionRow,
     );
 
@@ -208,7 +210,7 @@ export class CSVFileParser {
       for (const tag of tags) {
         tagsSet.add(tag);
         productionTagLinks.push({
-          legacyId: prodData.legacy_id!,
+          legacyId: prodData.legacy_id,
           tagName: tag,
         });
       }

--- a/backend/src/database/db.blog.service.ts
+++ b/backend/src/database/db.blog.service.ts
@@ -127,11 +127,7 @@ export class BlogDatabaseService {
    * The id field in the blog MUST be defined.
    * @returns the updated blog if successful.
    */
-  async updateBlog(blog: UpdateBlogDto): Promise<BlogDto> {
-    if (!blog.id) {
-      throw new BadRequestException("Blog id is required for update");
-    }
-
+  async updateBlog(blogId: number, blog: UpdateBlogDto): Promise<BlogDto> {
     const fields: string[] = [];
     const values: any[] = [];
     let index = 1;
@@ -152,7 +148,7 @@ export class BlogDatabaseService {
       throw new BadRequestException("No fields provided to update");
     }
 
-    values.push(blog.id);
+    values.push(blogId);
 
     const query = `
       UPDATE blogs
@@ -170,7 +166,7 @@ export class BlogDatabaseService {
 
     if (result.length === 0) {
       throw new ResourceGoneException(
-        `Cannot update: Blog ${blog.id} not found`,
+        `Cannot update: Blog ${blogId} not found`,
       );
     }
 

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -122,7 +122,7 @@ export class EventDatabaseService {
     // p is defined, ignore error
     // using SELECT * seems to be buggy sometimes, so explicitly use all vars.
     const query = `
-      SELECT e.id, e.starttime, e.endtime, e.production_id, e.legacy_id, e.created_at, e.updated_at
+      SELECT e.id, e.starttime, e.endtime, e.production_id, e.created_at, e.updated_at
       FROM events e
         JOIN productions p ON e.production_id = p.id
           ${whereClause}
@@ -158,9 +158,9 @@ export class EventDatabaseService {
     }
 
     const query = `
-      INSERT INTO events (starttime, endtime, production_id, intermission_at, doors_at, legacy_id)
-      VALUES ($1, $2, $3, $4, $5, $6)
-      RETURNING id, starttime, endtime, production_id, intermission_at, doors_at, created_at, updated_at, legacy_id
+      INSERT INTO events (starttime, endtime, production_id, intermission_at, doors_at)
+      VALUES ($1, $2, $3, $4, $5)
+      RETURNING id, starttime, endtime, production_id, intermission_at, doors_at, created_at, updated_at
     `;
 
     const result = await this.db.query<EventDto>(query, [
@@ -169,7 +169,6 @@ export class EventDatabaseService {
       event.production_id,
       event.intermission_at,
       event.doors_at,
-      event.legacy_id,
     ]);
 
     // Validate output
@@ -216,11 +215,6 @@ export class EventDatabaseService {
       values.push(event.intermission_at);
     }
 
-    if (event.legacy_id !== undefined) {
-      fields.push(`legacy_id = $${index++}`);
-      values.push(event.legacy_id);
-    }
-
     if (fields.length === 0) {
       throw new Error("No fields provided to update");
     }
@@ -232,7 +226,7 @@ export class EventDatabaseService {
     UPDATE events
     SET ${fields.join(", ")}
     WHERE id = $${index}
-    RETURNING *;
+    RETURNING id, starttime, endtime, production_id, intermission_at, doors_at, created_at, updated_at;
     `;
 
     const result = await this.db.query<EventDto>(query, values);
@@ -269,7 +263,7 @@ export class EventDatabaseService {
    */
   async getLocationOfEvent(id: number): Promise<LocationDto> {
     const query = `
-    SELECT l.id, l.location, l.legacy_id, l.created_at, l.updated_at
+    SELECT l.id, l.location, l.created_at, l.updated_at
     FROM locations l
     INNER JOIN event_locations el ON el.location_id = l.id
     WHERE el.event_id = $1
@@ -347,7 +341,6 @@ export class EventDatabaseService {
              p.updated_at,
              p.price,
              p.name,
-             p.legacy_id
       FROM prices p
       JOIN event_prices ep ON ep.price_id = p.id
       WHERE ep.event_id = $1
@@ -364,7 +357,6 @@ export class EventDatabaseService {
            p.name,
            p.created_at,
            p.updated_at,
-           p.legacy_id
     FROM prices p
     INNER JOIN event_prices ep ON ep.price_id = p.id
     WHERE ep.event_id = $1

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -216,6 +216,11 @@ export class EventDatabaseService {
       values.push(event.intermission_at);
     }
 
+    if (event.legacy_id !== undefined) {
+      fields.push(`legacy_id = $${index++}`);
+      values.push(event.legacy_id);
+    }
+
     if (fields.length === 0) {
       throw new Error("No fields provided to update");
     }

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -167,6 +167,9 @@ export class EventDatabaseService {
       event.starttime,
       event.endtime,
       event.production_id,
+      event.intermission_at,
+      event.doors_at,
+      event.legacy_id,
     ]);
 
     // Validate output

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -340,7 +340,7 @@ export class EventDatabaseService {
              p.created_at,
              p.updated_at,
              p.price,
-             p.name,
+             p.name
       FROM prices p
       JOIN event_prices ep ON ep.price_id = p.id
       WHERE ep.event_id = $1
@@ -356,7 +356,7 @@ export class EventDatabaseService {
            p.price,
            p.name,
            p.created_at,
-           p.updated_at,
+           p.updated_at
     FROM prices p
     INNER JOIN event_prices ep ON ep.price_id = p.id
     WHERE ep.event_id = $1

--- a/backend/src/database/db.event.service.ts
+++ b/backend/src/database/db.event.service.ts
@@ -186,11 +186,7 @@ export class EventDatabaseService {
    * The id field in the event MUST be defined.
    * @returns the updated event if successful.
    */
-  async updateEvent(event: UpdateEventDto): Promise<EventDto> {
-    if (!event.id) {
-      throw new Error("Event id is required for update");
-    }
-
+  async updateEvent(eventId: number, event: UpdateEventDto): Promise<EventDto> {
     const fields: string[] = [];
     const values: any[] = [];
     let index = 1;
@@ -224,7 +220,7 @@ export class EventDatabaseService {
       throw new Error("No fields provided to update");
     }
 
-    values.push(event.id);
+    values.push(eventId);
 
     // ignore error on "RETURNING", query is correct.
     const query = `

--- a/backend/src/database/db.location.service.ts
+++ b/backend/src/database/db.location.service.ts
@@ -94,7 +94,7 @@ export class LocationDatabaseService {
       ;
     `;
 
-    const values = [JSON.stringify(location.location)];
+    const values = [JSON.stringify(location.location), location.legacy_id];
 
     const result = await this.db.query<LocationDto>(query, values);
 
@@ -124,6 +124,11 @@ export class LocationDatabaseService {
         `location = COALESCE(location, '{}'::jsonb) || $${index++}::jsonb`,
       );
       values.push(JSON.stringify(location.location));
+    }
+
+    if (location.legacy_id !== undefined) {
+      fields.push(`legacy_id = $${index++}`);
+      values.push(location.legacy_id);
     }
 
     if (fields.length === 0) {

--- a/backend/src/database/db.location.service.ts
+++ b/backend/src/database/db.location.service.ts
@@ -22,8 +22,7 @@ export class LocationDatabaseService {
     const query = `SELECT id, 
        location, 
        created_at, 
-       updated_at, 
-       legacy_id 
+       updated_at
       FROM locations WHERE id = $1`;
 
     const result = await this.db.query<LocationDto>(query, [id]);
@@ -45,7 +44,7 @@ export class LocationDatabaseService {
     page: number = 0,
   ): Promise<PaginatedLocationDto> {
     let query = `
-    SELECT id, location, created_at, updated_at, legacy_id
+    SELECT id, location, created_at, updated_at
     FROM locations
     ORDER BY id
   `;
@@ -83,18 +82,17 @@ export class LocationDatabaseService {
     }
 
     const query = `
-      INSERT INTO locations (location, legacy_id)
-      VALUES ($1, $2)
+      INSERT INTO locations (location)
+      VALUES ($1)
       RETURNING
         id,
         location,
         created_at,
-        updated_at,
-        legacy_id
+        updated_at
       ;
     `;
 
-    const values = [JSON.stringify(location.location), location.legacy_id];
+    const values = [JSON.stringify(location.location)];
 
     const result = await this.db.query<LocationDto>(query, values);
 
@@ -126,11 +124,6 @@ export class LocationDatabaseService {
       values.push(JSON.stringify(location.location));
     }
 
-    if (location.legacy_id !== undefined) {
-      fields.push(`legacy_id = $${index++}`);
-      values.push(location.legacy_id);
-    }
-
     if (fields.length === 0) {
       throw new BadRequestException("No fields provided to update");
     }
@@ -145,8 +138,7 @@ export class LocationDatabaseService {
       id,
       location,
       created_at,
-      updated_at,
-      legacy_id
+      updated_at
     ;
   `;
 

--- a/backend/src/database/db.location.service.ts
+++ b/backend/src/database/db.location.service.ts
@@ -111,11 +111,10 @@ export class LocationDatabaseService {
    * The id field in the location MUST be defined.
    * @returns the updated location if successful.
    */
-  async updateLocation(location: UpdateLocationDto): Promise<LocationDto> {
-    if (!location.id) {
-      throw new BadRequestException("Location id is required for update");
-    }
-
+  async updateLocation(
+    locationId: number,
+    location: UpdateLocationDto,
+  ): Promise<LocationDto> {
     const fields: string[] = [];
     const values: any[] = [];
     let index = 1;
@@ -131,7 +130,7 @@ export class LocationDatabaseService {
       throw new BadRequestException("No fields provided to update");
     }
 
-    values.push(location.id);
+    values.push(locationId);
 
     const query = `
       UPDATE locations
@@ -150,7 +149,7 @@ export class LocationDatabaseService {
 
     if (result.length === 0) {
       throw new ResourceGoneException(
-        `Location with ID ${location.id} not found`,
+        `Location with ID ${locationId} not found`,
       );
     }
 

--- a/backend/src/database/db.price.service.ts
+++ b/backend/src/database/db.price.service.ts
@@ -6,6 +6,7 @@ import {
   PriceDto,
   UpdatePriceDto,
 } from "../dto/dto";
+import { ResourceGoneException } from "src/common/exceptions";
 
 @Injectable()
 export class PriceDatabaseService {
@@ -105,11 +106,7 @@ export class PriceDatabaseService {
    * The id field in the price MUST be defined.
    * @returns the updated price if successful.
    */
-  async updatePrice(price: UpdatePriceDto): Promise<PriceDto> {
-    if (!price.id) {
-      throw new BadRequestException("Price id is required for update");
-    }
-
+  async updatePrice(priceId: number, price: UpdatePriceDto): Promise<PriceDto> {
     const fields: string[] = [];
     const values: any[] = [];
     let index = 1;
@@ -128,7 +125,7 @@ export class PriceDatabaseService {
       throw new BadRequestException("No valid fields to update");
     }
 
-    values.push(price.id);
+    values.push(priceId);
 
     const query = `
       UPDATE prices
@@ -146,7 +143,9 @@ export class PriceDatabaseService {
     const result = await this.db.query<PriceDto>(query, values);
 
     if (result.length === 0) {
-      throw new Error("Failed to update price");
+      throw new ResourceGoneException(
+        `Failed to update price with ID ${priceId}.`,
+      );
     }
 
     return result[0];

--- a/backend/src/database/db.price.service.ts
+++ b/backend/src/database/db.price.service.ts
@@ -121,6 +121,11 @@ export class PriceDatabaseService {
       values.push(price.price);
     }
 
+    if (price.legacy_id !== undefined) {
+      fields.push(`legacy_id = $${index++}`);
+      values.push(price.legacy_id);
+    }
+
     if (fields.length === 0) {
       throw new BadRequestException("No valid fields to update");
     }

--- a/backend/src/database/db.price.service.ts
+++ b/backend/src/database/db.price.service.ts
@@ -23,8 +23,7 @@ export class PriceDatabaseService {
        price, 
        name, 
        created_at, 
-       updated_at, 
-       legacy_id 
+       updated_at
       FROM prices WHERE id = $1`;
     const result = await this.db.query<PriceDto>(query, [id]);
 
@@ -42,7 +41,7 @@ export class PriceDatabaseService {
     page: number = 0,
   ): Promise<PaginatedPriceDto> {
     let query = `
-    SELECT id, price, name, created_at, updated_at, legacy_id
+    SELECT id, price, name, created_at, updated_at
     FROM prices
     ORDER BY id
   `;
@@ -78,18 +77,18 @@ export class PriceDatabaseService {
     }
 
     const query = `
-      INSERT INTO prices (name, price, legacy_id)
-      VALUES ($1, $2, $3)
+      INSERT INTO prices (name, price)
+      VALUES ($1, $2)
       RETURNING
         id,
         name,
         price,
         created_at,
-        updated_at,
-        legacy_id;
+        updated_at
+      ;
     `;
 
-    const values = [JSON.stringify(price.name), price.price, price.legacy_id];
+    const values = [JSON.stringify(price.name), price.price];
 
     const result = await this.db.query<PriceDto>(query, values);
 
@@ -121,11 +120,6 @@ export class PriceDatabaseService {
       values.push(price.price);
     }
 
-    if (price.legacy_id !== undefined) {
-      fields.push(`legacy_id = $${index++}`);
-      values.push(price.legacy_id);
-    }
-
     if (fields.length === 0) {
       throw new BadRequestException("No valid fields to update");
     }
@@ -141,8 +135,8 @@ export class PriceDatabaseService {
         name,
         price,
         created_at,
-        updated_at,
-        legacy_id;
+        updated_at
+      ;
     `;
 
     const result = await this.db.query<PriceDto>(query, values);

--- a/backend/src/database/db.price.service.ts
+++ b/backend/src/database/db.price.service.ts
@@ -88,7 +88,7 @@ export class PriceDatabaseService {
         legacy_id;
     `;
 
-    const values = [JSON.stringify(price.name), price.price];
+    const values = [JSON.stringify(price.name), price.price, price.legacy_id];
 
     const result = await this.db.query<PriceDto>(query, values);
 

--- a/backend/src/database/db.price.service.ts
+++ b/backend/src/database/db.price.service.ts
@@ -6,7 +6,7 @@ import {
   PriceDto,
   UpdatePriceDto,
 } from "../dto/dto";
-import { ResourceGoneException } from "src/common/exceptions";
+import { ResourceGoneException } from "../common/exceptions";
 
 @Injectable()
 export class PriceDatabaseService {

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -425,12 +425,9 @@ export class ProductionDatabaseService {
    * @returns the updated production if successful.
    */
   async updateProduction(
+    productionId: number,
     production: UpdateProductionDto,
   ): Promise<ProductionDto> {
-    if (!production.id) {
-      throw new BadRequestException("Production id is required for update");
-    }
-
     const fields: string[] = [];
     const values: any[] = [];
     let index = 1;
@@ -472,7 +469,7 @@ export class ProductionDatabaseService {
       throw new BadRequestException("No fields provided to update");
     }
 
-    values.push(production.id);
+    values.push(productionId);
     const query = `
       UPDATE productions
       SET ${fields.join(", ")}

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -51,7 +51,6 @@ export class ProductionDatabaseService {
       const query = `
       SELECT t.id,
              t.tag,
-             t.legacy_id,
              t.created_at,
              t.updated_at
       FROM tags t
@@ -69,7 +68,6 @@ export class ProductionDatabaseService {
              t.tag,
              t.created_at,
              t.updated_at,
-             t.legacy_id
       FROM tags t
       JOIN production_tag pt ON t.id = pt.tag_id
       WHERE pt.production_id = $1
@@ -114,7 +112,6 @@ export class ProductionDatabaseService {
              b.description,
              b.created_at,
              b.updated_at,
-             b.legacy_id
       FROM blogs b
       JOIN production_blogs pb ON b.id = pb.blog_id
       WHERE pb.production_id = $1
@@ -265,7 +262,6 @@ export class ProductionDatabaseService {
       p.credits,
       p.created_at,
       p.updated_at,
-      p.legacy_id,
       p.performer_type,
       p.attendance_mode
     FROM productions p
@@ -309,11 +305,10 @@ export class ProductionDatabaseService {
           artist,
           tagline,
           credits,
-          legacy_id,
           performer_type,
           attendance_mode
       )
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
       RETURNING
           id,
           titel,
@@ -324,7 +319,6 @@ export class ProductionDatabaseService {
           credits,
           created_at,
           updated_at,
-          legacy_id,
           performer_type,
           attendance_mode;
       `;
@@ -336,7 +330,6 @@ export class ProductionDatabaseService {
       production.artist,
       production.tagline,
       production.credits,
-      production.legacy_id,
       production.performer_type,
       production.attendance_mode,
     ];
@@ -365,11 +358,10 @@ export class ProductionDatabaseService {
         artist,
         tagline,
         credits,
-        legacy_id,
         performer_type,
         attendance_mode
       )
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
       ON CONFLICT (id)
       DO UPDATE SET
         titel = EXCLUDED.titel,
@@ -378,7 +370,6 @@ export class ProductionDatabaseService {
         artist = EXCLUDED.artist,
         tagline = EXCLUDED.tagline,
         credits = EXCLUDED.credits,
-        legacy_id = EXCLUDED.legacy_id,
         performer_type = EXCLUDED.performer_type,
         attendance_mode = EXCLUDED.attendance_mode
         RETURNING
@@ -391,7 +382,6 @@ export class ProductionDatabaseService {
           credits,
           created_at,
           updated_at,
-          legacy_id,
           performer_type,
           attendance_mode
       `;
@@ -403,7 +393,6 @@ export class ProductionDatabaseService {
       production.artist,
       production.tagline,
       production.credits,
-      production.legacy_id ?? null,
       production.performer_type ?? null,
       production.attendance_mode ?? null,
     ];
@@ -450,11 +439,6 @@ export class ProductionDatabaseService {
       }
     }
 
-    if (production.legacy_id !== undefined) {
-      fields.push(`legacy_id = $${index++}`);
-      values.push(production.legacy_id);
-    }
-
     if (production.performer_type !== undefined) {
       fields.push(`performer_type = $${index++}`);
       values.push(production.performer_type);
@@ -484,7 +468,6 @@ export class ProductionDatabaseService {
         credits,
         created_at,
         updated_at,
-        legacy_id,
         performer_type,
         attendance_mode;
     `;

--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -234,6 +234,7 @@ export class ProductionDatabaseService {
       conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
     // count query uses same filters but no pagination
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const filterValues = [...values];
     const countQuery = `
     SELECT COUNT(DISTINCT p.id) as count

--- a/backend/src/database/db.tag.service.ts
+++ b/backend/src/database/db.tag.service.ts
@@ -109,11 +109,7 @@ export class TagDatabaseService {
    * The id field in the tag MUST be defined.
    * @returns the updated tag if successful.
    */
-  async updateTag(tag: UpdateTagDto): Promise<TagDto> {
-    if (!tag.id) {
-      throw new BadRequestException("Tag id is required for update");
-    }
-
+  async updateTag(tagId: number, tag: UpdateTagDto): Promise<TagDto> {
     const fields: string[] = [];
     const values: any[] = [];
     let index = 1;
@@ -127,7 +123,7 @@ export class TagDatabaseService {
       throw new BadRequestException("No fields provided to update");
     }
 
-    values.push(tag.id);
+    values.push(tagId);
 
     const query = `
       UPDATE tags
@@ -145,7 +141,7 @@ export class TagDatabaseService {
     const result = await this.db.query<TagDto>(query, values);
 
     if (result.length === 0) {
-      throw new ResourceGoneException("Tag not found");
+      throw new ResourceGoneException(`Tag with ID ${tagId} not found`);
     }
 
     return result[0];

--- a/backend/src/database/db.tag.service.ts
+++ b/backend/src/database/db.tag.service.ts
@@ -24,7 +24,7 @@ export class TagDatabaseService {
         id,
         tag,
         created_at,
-        updated_at,
+        updated_at
       FROM tags
       WHERE id = $1
     `;

--- a/backend/src/database/db.tag.service.ts
+++ b/backend/src/database/db.tag.service.ts
@@ -25,7 +25,6 @@ export class TagDatabaseService {
         tag,
         created_at,
         updated_at,
-        legacy_id
       FROM tags
       WHERE id = $1
     `;
@@ -48,7 +47,7 @@ export class TagDatabaseService {
     amount: number = 0,
     page: number = 0,
   ): Promise<PaginatedTagDto> {
-    let query = `SELECT id, tag, created_at, updated_at, legacy_id FROM tags ORDER BY id`;
+    let query = `SELECT id, tag, created_at, updated_at FROM tags ORDER BY id`;
 
     const params: any[] = [];
 
@@ -81,18 +80,17 @@ export class TagDatabaseService {
     }
 
     const query = `
-      INSERT INTO tags (tag, legacy_id)
-      VALUES ($1, $2)
+      INSERT INTO tags (tag)
+      VALUES ($1)
       RETURNING
         id,
         tag,
         created_at,
-        updated_at,
-        legacy_id
+        updated_at
       ;
     `;
 
-    const values = [JSON.stringify(tag.tag), tag.legacy_id];
+    const values = [JSON.stringify(tag.tag)];
 
     const result = await this.db.query<TagDto>(query, values);
 
@@ -119,11 +117,6 @@ export class TagDatabaseService {
       values.push(JSON.stringify(tag.tag));
     }
 
-    if (tag.legacy_id !== undefined) {
-      fields.push(`legacy_id = $${index++}`);
-      values.push(tag.legacy_id);
-    }
-
     if (fields.length === 0) {
       throw new BadRequestException("No fields provided to update");
     }
@@ -138,8 +131,7 @@ export class TagDatabaseService {
         id,
         tag,
         created_at,
-        updated_at,
-        legacy_id
+        updated_at
       ;
     `;
 

--- a/backend/src/database/db.tag.service.ts
+++ b/backend/src/database/db.tag.service.ts
@@ -92,7 +92,7 @@ export class TagDatabaseService {
       ;
     `;
 
-    const values = [JSON.stringify(tag.tag)];
+    const values = [JSON.stringify(tag.tag), tag.legacy_id];
 
     const result = await this.db.query<TagDto>(query, values);
 
@@ -117,6 +117,11 @@ export class TagDatabaseService {
     if (tag.tag !== undefined) {
       fields.push(`tag = COALESCE(tag, '{}'::jsonb) || $${index++}::jsonb`);
       values.push(JSON.stringify(tag.tag));
+    }
+
+    if (tag.legacy_id !== undefined) {
+      fields.push(`legacy_id = $${index++}`);
+      values.push(tag.legacy_id);
     }
 
     if (fields.length === 0) {

--- a/backend/src/event/controllers/event-location.controller.spec.ts
+++ b/backend/src/event/controllers/event-location.controller.spec.ts
@@ -19,7 +19,6 @@ describe("EventLocationController", () => {
     },
     created_at: "2025-06-01T22:00:00.000Z",
     updated_at: "2025-06-01T22:00:00.000Z",
-    legacy_id: "str",
   };
 
   // What we expect the LanguageService to return after flattening
@@ -28,7 +27,6 @@ describe("EventLocationController", () => {
     location: "Citadel Park",
     created_at: "2025-06-01T22:00:00.000Z",
     updated_at: "2025-06-01T22:00:00.000Z",
-    legacy_id: "str",
   };
 
   const mockEventId = 42;

--- a/backend/src/event/controllers/event-location.controller.ts
+++ b/backend/src/event/controllers/event-location.controller.ts
@@ -22,8 +22,8 @@ import { ApiOkAnyOf } from "../../common/decorators/api.ok";
 import { LanguageQuerySchema } from "@repo/common";
 import { ZodValidationPipe } from "nestjs-zod";
 
-@ApiTags("Events - Locations")
-@Controller("events/:eventId/locations")
+@ApiTags("Events - Location")
+@Controller("events/:eventId/location")
 export class EventLocationController {
   constructor(
     private readonly eventService: EventService,

--- a/backend/src/event/controllers/event-price.controller.spec.ts
+++ b/backend/src/event/controllers/event-price.controller.spec.ts
@@ -69,7 +69,6 @@ describe("EventPriceController", () => {
           name: { en: "Early Bird", nl: "Vroege vogel" },
           created_at: "2024-01-15T19:00:00Z",
           updated_at: "2024-01-15T19:00:00Z",
-          legacy_id: null,
         },
       ];
 
@@ -81,7 +80,6 @@ describe("EventPriceController", () => {
           name: "Early Bird",
           created_at: "2024-01-15T19:00:00Z",
           updated_at: "2024-01-15T19:00:00Z",
-          legacy_id: null,
         },
       ];
 

--- a/backend/src/event/controllers/event.controller.spec.ts
+++ b/backend/src/event/controllers/event.controller.spec.ts
@@ -19,7 +19,6 @@ describe("EventController", () => {
     intermission_at: "2024-01-15T19:00:00Z",
     created_at: "2024-01-15T19:00:00Z",
     updated_at: "2024-01-15T19:00:00Z",
-    legacy_id: "str",
   };
 
   const mockEvents: EventDto[] = [mockEvent];
@@ -72,9 +71,19 @@ describe("EventController", () => {
     });
 
     it("should return empty array when no events exist", async () => {
-      jest.spyOn(service, "getAllEvents").mockResolvedValueOnce([]);
+      jest.spyOn(service, "getAllEvents").mockResolvedValueOnce({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
       const result = await controller.getAllEvents(FilterEventSchema.parse({}));
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
     });
   });
 
@@ -184,7 +193,6 @@ describe("EventController", () => {
         production_id: 1,
         doors_at: "2024-01-15T19:00:00Z",
         intermission_at: "2024-01-15T19:00:00Z",
-        legacy_id: "str",
       };
 
       const createdEvent: EventDto = {
@@ -209,7 +217,6 @@ describe("EventController", () => {
         production_id: 1,
         doors_at: "2024-01-15T19:00:00Z",
         intermission_at: "2024-01-15T19:00:00Z",
-        legacy_id: "str",
       };
 
       jest

--- a/backend/src/event/event.service.spec.ts
+++ b/backend/src/event/event.service.spec.ts
@@ -1,12 +1,12 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import EventService from "./event.service";
 import { EventDatabaseService } from "../database/db.event.service";
-import type {
-  CreateEventDto,
-  EventDto,
-  LocationDto,
-  PriceDto,
-  UpdateEventDto,
+import {
+  type CreateEventDto,
+  type EventDto,
+  type LocationDto,
+  type PriceDto,
+  type UpdateEventDto,
 } from "../dto/dto";
 import { BadRequestException } from "@nestjs/common";
 import { BlogDatabaseService } from "../database/db.blog.service";
@@ -129,9 +129,19 @@ describe("EventService", () => {
     });
 
     it("should return empty array when no events exist", async () => {
-      jest.spyOn(dbService, "getEvents").mockResolvedValueOnce([]);
+      jest.spyOn(dbService, "getEvents").mockResolvedValueOnce({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
       const result = await service.getAllEvents(FilterEventSchema.parse({}));
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
     });
 
     it("should handle database errors", async () => {

--- a/backend/src/event/event.service.spec.ts
+++ b/backend/src/event/event.service.spec.ts
@@ -25,7 +25,6 @@ describe("EventService", () => {
     intermission_at: "2024-01-15T19:00:00Z",
     created_at: "2024-01-15T19:00:00Z",
     updated_at: "2024-01-15T19:00:00Z",
-    legacy_id: "str",
   };
 
   // Updated Location to use LocalizedStringSchema
@@ -37,7 +36,6 @@ describe("EventService", () => {
     },
     created_at: "2025-06-01T22:00:00.000Z",
     updated_at: "2025-06-01T22:00:00.000Z",
-    legacy_id: "str",
   };
 
   // Updated Blog to use LocalizedStringSchema (even if it's just mocked for db configuration)
@@ -66,7 +64,6 @@ describe("EventService", () => {
       },
       created_at: "2024-01-15T19:00:00Z",
       updated_at: "2024-01-15T19:00:00Z",
-      legacy_id: null,
     },
   ];
 
@@ -181,7 +178,7 @@ describe("EventService", () => {
   describe("replaceEvent", () => {
     it("should successfully replace and return the event", async () => {
       const result = await service.replaceEvent(1, mockEvent);
-      expect(dbService.updateEvent).toHaveBeenCalledWith(mockEvent);
+      expect(dbService.updateEvent).toHaveBeenCalledWith(1, mockEvent);
       expect(result).toEqual(mockEvent);
     });
 
@@ -213,7 +210,10 @@ describe("EventService", () => {
       const result = await service.modifyEvent(1, patchData);
 
       expect(dbService.getEventById).toHaveBeenCalledWith(1);
-      expect(dbService.updateEvent).toHaveBeenCalledWith(expectedMergedEvent);
+      expect(dbService.updateEvent).toHaveBeenCalledWith(
+        1,
+        expectedMergedEvent,
+      );
       expect(result).toEqual(expectedMergedEvent);
     });
   });
@@ -244,7 +244,6 @@ describe("EventService", () => {
         production_id: 1,
         doors_at: "2024-01-15T19:00:00Z",
         intermission_at: "2024-01-15T19:00:00Z",
-        legacy_id: "str",
       };
 
       const createdEvent: EventDto = {
@@ -269,7 +268,6 @@ describe("EventService", () => {
         production_id: 1,
         doors_at: "2024-01-15T19:00:00Z",
         intermission_at: "2024-01-15T19:00:00Z",
-        legacy_id: "str",
       };
 
       jest

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -43,7 +43,7 @@ export class EventService {
     if (id !== event.id)
       throw new BadRequestException("ID in the URL must match ID in the body.");
 
-    return await this.eventDBService.updateEvent(event);
+    return await this.eventDBService.updateEvent(id, event);
   }
 
   /**
@@ -61,7 +61,7 @@ export class EventService {
       id, // Force ID.
     };
 
-    return await this.eventDBService.updateEvent(mergedEvent);
+    return await this.eventDBService.updateEvent(id, mergedEvent);
   }
 
   /**

--- a/backend/src/location/location.controller.spec.ts
+++ b/backend/src/location/location.controller.spec.ts
@@ -26,7 +26,6 @@ describe("LocationController", () => {
     },
     created_at: "2025-06-01T22:00:00.000Z",
     updated_at: "2025-06-01T22:00:00.000Z",
-    legacy_id: "str",
   };
 
   // What the LanguageService returns after flattening
@@ -35,7 +34,6 @@ describe("LocationController", () => {
     location: "Citadel Park",
     created_at: "2025-06-01T22:00:00.000Z",
     updated_at: "2025-06-01T22:00:00.000Z",
-    legacy_id: "str",
   };
 
   const mockLocationArray: LocationDto[] = [mockLocation];
@@ -133,7 +131,6 @@ describe("LocationController", () => {
     it("should create and return a new location", async () => {
       const dto: CreateLocationDto = {
         location: { en: "Citadel Park", nl: "Citadelpark" },
-        legacy_id: null,
       };
       const result = await controller.createLocation(dto);
 
@@ -145,7 +142,6 @@ describe("LocationController", () => {
   describe("updateLocation", () => {
     it("should update and return the location", async () => {
       const dto: UpdateLocationDto = {
-        id: 1,
         location: { en: "Updated Park", nl: "Bijgewerkt park" },
       };
       const result = await controller.updateLocation(1, dto);

--- a/backend/src/location/location.controller.spec.ts
+++ b/backend/src/location/location.controller.spec.ts
@@ -148,10 +148,10 @@ describe("LocationController", () => {
         id: 1,
         location: { en: "Updated Park", nl: "Bijgewerkt park" },
       };
-      const result = await controller.updateLocation(dto);
+      const result = await controller.updateLocation(1, dto);
 
       expect(result).toEqual(mockLocation);
-      expect(service.updateLocation).toHaveBeenCalledWith(dto);
+      expect(service.updateLocation).toHaveBeenCalledWith(1, dto);
     });
   });
 

--- a/backend/src/location/location.controller.ts
+++ b/backend/src/location/location.controller.ts
@@ -104,7 +104,8 @@ export class LocationController {
   }
 
   /**
-   * Responds to a PATCH to "/locations"
+   * Responds to a PATCH to "/locations/:locationId"
+   * @param locationId The ID of the Location in the URL.
    * @param updateLocation The Location we want to update.
    * @returns The newly updated Location.
    */
@@ -116,12 +117,16 @@ export class LocationController {
     type: LocationDto,
     description: "The Location was updated.",
   })
-  @UsePipes(new ZodValidationPipe(UpdateLocationSchema))
-  @Patch()
+  @Patch(":locationId")
   async updateLocation(
-    @Body() updateLocation: UpdateLocationDto,
+    @Param("locationId", ParseIntPipe) locationId: number,
+    @Body(new ZodValidationPipe(UpdateLocationSchema))
+    updateLocation: UpdateLocationDto,
   ): Promise<LocationDto> {
-    return await this.locationService.updateLocation(updateLocation);
+    return await this.locationService.updateLocation(
+      locationId,
+      updateLocation,
+    );
   }
 
   /**

--- a/backend/src/location/location.service.spec.ts
+++ b/backend/src/location/location.service.spec.ts
@@ -21,7 +21,6 @@ describe("LocationService", () => {
     },
     created_at: "2025-06-01T22:00:00.000Z",
     updated_at: "2025-06-01T22:00:00.000Z",
-    legacy_id: "str",
   };
 
   const filter: PaginationFilterDto = {
@@ -79,7 +78,6 @@ describe("LocationService", () => {
     it("should create a location in the database", async () => {
       const dto: CreateLocationDto = {
         location: { en: "Citadel Park", nl: "Citadelpark" },
-        legacy_id: null,
       };
       const result = await service.createLocation(dto);
       expect(result).toEqual(mockLocation);
@@ -90,12 +88,11 @@ describe("LocationService", () => {
   describe("updateLocation", () => {
     it("should update a location in the database", async () => {
       const dto: UpdateLocationDto = {
-        id: 1,
         location: { en: "Updated Park", nl: "Bijgewerkt park" },
       };
       const result = await service.updateLocation(1, dto);
       expect(result).toEqual(mockLocation);
-      expect(dbService.updateLocation).toHaveBeenCalledWith(dto);
+      expect(dbService.updateLocation).toHaveBeenCalledWith(1, dto);
     });
   });
 

--- a/backend/src/location/location.service.spec.ts
+++ b/backend/src/location/location.service.spec.ts
@@ -93,7 +93,7 @@ describe("LocationService", () => {
         id: 1,
         location: { en: "Updated Park", nl: "Bijgewerkt park" },
       };
-      const result = await service.updateLocation(dto);
+      const result = await service.updateLocation(1, dto);
       expect(result).toEqual(mockLocation);
       expect(dbService.updateLocation).toHaveBeenCalledWith(dto);
     });

--- a/backend/src/location/location.service.ts
+++ b/backend/src/location/location.service.ts
@@ -51,6 +51,7 @@ export class LocationService {
 
   /**
    * Updates an existing Location.
+   * @param locationId The ID of the Location.
    * @param updateLocation The Location we want to update.
    * @returns The updated Location.
    */
@@ -58,8 +59,10 @@ export class LocationService {
     locationId: number,
     updateLocation: UpdateLocationDto,
   ): Promise<LocationDto> {
-    updateLocation.id = locationId; // Set the location ID to the one in the URL.
-    return await this.locationDbService.updateLocation(updateLocation);
+    return await this.locationDbService.updateLocation(
+      locationId,
+      updateLocation,
+    );
   }
 
   /**

--- a/backend/src/location/location.service.ts
+++ b/backend/src/location/location.service.ts
@@ -55,8 +55,10 @@ export class LocationService {
    * @returns The updated Location.
    */
   async updateLocation(
+    locationId: number,
     updateLocation: UpdateLocationDto,
   ): Promise<LocationDto> {
+    updateLocation.id = locationId; // Set the location ID to the one in the URL.
     return await this.locationDbService.updateLocation(updateLocation);
   }
 

--- a/backend/src/price/price.controller.spec.ts
+++ b/backend/src/price/price.controller.spec.ts
@@ -40,7 +40,6 @@ describe("PriceController", () => {
     },
     created_at: "2024-01-15T19:00:00Z",
     updated_at: "2024-01-15T19:00:00Z",
-    legacy_id: null,
   };
 
   // What the LanguageService will output
@@ -50,7 +49,6 @@ describe("PriceController", () => {
     name: "Standard",
     created_at: "2024-01-15T19:00:00Z",
     updated_at: "2024-01-15T19:00:00Z",
-    legacy_id: null,
   };
 
   beforeEach(async () => {
@@ -127,7 +125,6 @@ describe("PriceController", () => {
       const createDto: CreatePriceDto = {
         price: 20.0,
         name: { en: "Standard", nl: "Standaard" },
-        legacy_id: null,
       };
       mockPriceService.createPrice.mockResolvedValue(mockPrice);
 
@@ -141,7 +138,6 @@ describe("PriceController", () => {
   describe("updatePrice", () => {
     it("should call updatePrice on the service and return the updated price", async () => {
       const updateDto: UpdatePriceDto = {
-        id: 1,
         price: 25.0,
       };
       const updatedPrice = { ...mockPrice, price: 25.0 };

--- a/backend/src/price/price.controller.spec.ts
+++ b/backend/src/price/price.controller.spec.ts
@@ -147,9 +147,9 @@ describe("PriceController", () => {
       const updatedPrice = { ...mockPrice, price: 25.0 };
       mockPriceService.updatePrice.mockResolvedValue(updatedPrice);
 
-      const result = await controller.updatePrice(updateDto);
+      const result = await controller.updatePrice(1, updateDto);
 
-      expect(service.updatePrice).toHaveBeenCalledWith(updateDto);
+      expect(service.updatePrice).toHaveBeenCalledWith(1, updateDto);
       expect(result).toEqual(updatedPrice);
     });
   });

--- a/backend/src/price/price.controller.ts
+++ b/backend/src/price/price.controller.ts
@@ -5,8 +5,8 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
-  Put,
   Query,
   UseGuards,
   UsePipes,
@@ -112,10 +112,12 @@ export class PriceController {
   @ApiOperation({ summary: "Updates an existing Price object." })
   @ApiBody({ type: UpdatePriceDto })
   @ApiOkResponse({ type: PriceDto, description: "Updated Price." })
-  @UsePipes(new ZodValidationPipe(UpdatePriceSchema))
-  @Put()
-  async updatePrice(@Body() updatePrice: UpdatePriceDto): Promise<PriceDto> {
-    return await this.priceService.updatePrice(updatePrice);
+  @Patch(":priceId")
+  async updatePrice(
+    @Param("priceId", ParseIntPipe) priceId: number,
+    @Body(new ZodValidationPipe(UpdatePriceSchema)) updatePrice: UpdatePriceDto,
+  ): Promise<PriceDto> {
+    return await this.priceService.updatePrice(priceId, updatePrice);
   }
 
   /**

--- a/backend/src/price/price.service.spec.ts
+++ b/backend/src/price/price.service.spec.ts
@@ -32,7 +32,6 @@ describe("PriceService", () => {
     },
     created_at: "2024-01-15T19:00:00Z",
     updated_at: "2024-01-15T19:00:00Z",
-    legacy_id: null,
   };
 
   beforeEach(async () => {
@@ -95,7 +94,6 @@ describe("PriceService", () => {
       const createDto: CreatePriceDto = {
         price: 20.0,
         name: { en: "Standard", nl: "Standaard" },
-        legacy_id: null,
       };
       mockPriceDatabaseService.createPrice.mockResolvedValue(mockPrice);
 
@@ -109,7 +107,6 @@ describe("PriceService", () => {
   describe("updatePrice", () => {
     it("should call updatePrice on the db service and return the updated price", async () => {
       const updateDto: UpdatePriceDto = {
-        id: 1,
         price: 25.0,
       };
       const updatedPrice = { ...mockPrice, price: 25.0 };
@@ -117,7 +114,7 @@ describe("PriceService", () => {
 
       const result = await service.updatePrice(1, updateDto);
 
-      expect(dbService.updatePrice).toHaveBeenCalledWith(updateDto);
+      expect(dbService.updatePrice).toHaveBeenCalledWith(1, updateDto);
       expect(result).toEqual(updatedPrice);
     });
   });

--- a/backend/src/price/price.service.spec.ts
+++ b/backend/src/price/price.service.spec.ts
@@ -115,7 +115,7 @@ describe("PriceService", () => {
       const updatedPrice = { ...mockPrice, price: 25.0 };
       mockPriceDatabaseService.updatePrice.mockResolvedValue(updatedPrice);
 
-      const result = await service.updatePrice(updateDto);
+      const result = await service.updatePrice(1, updateDto);
 
       expect(dbService.updatePrice).toHaveBeenCalledWith(updateDto);
       expect(result).toEqual(updatedPrice);

--- a/backend/src/price/price.service.ts
+++ b/backend/src/price/price.service.ts
@@ -48,7 +48,11 @@ export class PriceService {
    * @param updatePrice The needed values to update the Price.
    * @returns The newly updated Price object.
    */
-  async updatePrice(updatePrice: UpdatePriceDto): Promise<PriceDto> {
+  async updatePrice(
+    priceId: number,
+    updatePrice: UpdatePriceDto,
+  ): Promise<PriceDto> {
+    updatePrice.id = priceId;
     return await this.priceDbService.updatePrice(updatePrice);
   }
 

--- a/backend/src/price/price.service.ts
+++ b/backend/src/price/price.service.ts
@@ -45,6 +45,7 @@ export class PriceService {
 
   /**
    * Updates an existing Price in the database.
+   * @param priceId The ID of the price.
    * @param updatePrice The needed values to update the Price.
    * @returns The newly updated Price object.
    */
@@ -52,8 +53,7 @@ export class PriceService {
     priceId: number,
     updatePrice: UpdatePriceDto,
   ): Promise<PriceDto> {
-    updatePrice.id = priceId;
-    return await this.priceDbService.updatePrice(updatePrice);
+    return await this.priceDbService.updatePrice(priceId, updatePrice);
   }
 
   /**

--- a/backend/src/production/controllers/production-blog.controller.spec.ts
+++ b/backend/src/production/controllers/production-blog.controller.spec.ts
@@ -26,7 +26,6 @@ describe("ProductionBlogController", () => {
     description2: { en: "With great actors", nl: "Met geweldige acteurs" },
     performer_type: "happy",
     attendance_mode: "I",
-    legacy_id: "am",
     tagline: { en: "fixing", nl: "repareren" },
     artist: { en: "the", nl: "de" },
     credits: { en: "tests :-)", nl: "testen :-)" },

--- a/backend/src/production/controllers/production-tag.controller.spec.ts
+++ b/backend/src/production/controllers/production-tag.controller.spec.ts
@@ -26,7 +26,6 @@ describe("ProductionTagController", () => {
     description2: { en: "With great actors", nl: "Met geweldige acteurs" },
     performer_type: "happy",
     attendance_mode: "I",
-    legacy_id: "am",
     tagline: { en: "fixing", nl: "repareren" },
     artist: { en: "the", nl: "de" },
     credits: { en: "tests :-)", nl: "testen :-)" },
@@ -40,7 +39,6 @@ describe("ProductionTagController", () => {
       tag: { en: "Drama", nl: "Drama" },
       created_at: "2025-06-01T22:00:00.000Z",
       updated_at: "2025-06-01T22:00:00.000Z",
-      legacy_id: "str",
     },
   ];
 
@@ -50,7 +48,6 @@ describe("ProductionTagController", () => {
       tag: "Drama",
       created_at: "2025-06-01T22:00:00.000Z",
       updated_at: "2025-06-01T22:00:00.000Z",
-      legacy_id: "str",
     },
   ];
 

--- a/backend/src/production/controllers/production.controller.spec.ts
+++ b/backend/src/production/controllers/production.controller.spec.ts
@@ -28,7 +28,6 @@ describe("ProductionController", () => {
     description2: { en: "With great actors", nl: "Met geweldige acteurs" },
     performer_type: "happy",
     attendance_mode: "I",
-    legacy_id: "am",
     tagline: { en: "fixing", nl: "repareren" },
     artist: { en: "the", nl: "de" },
     credits: { en: "tests :-)", nl: "testen :-)" },
@@ -43,7 +42,6 @@ describe("ProductionController", () => {
     description2: "With great actors",
     performer_type: "happy",
     attendance_mode: "I",
-    legacy_id: "am",
     tagline: "fixing",
     artist: "the",
     credits: "tests :-)",
@@ -117,12 +115,27 @@ describe("ProductionController", () => {
 
     it("should return empty array when no productions exist", async () => {
       const filters = FilterProductionSchema.parse({ lang: "en" });
-      jest.spyOn(service, "getAllProductions").mockResolvedValueOnce([]);
-      jest.spyOn(languageService, "flattenByLanguage").mockReturnValue([]);
+      jest.spyOn(service, "getAllProductions").mockResolvedValueOnce({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
+      jest.spyOn(languageService, "flattenByLanguage").mockReturnValue({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
 
       const result = await controller.getAllProductions(filters);
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
     });
   });
 
@@ -232,7 +245,6 @@ describe("ProductionController", () => {
         description2: { en: "With great actors", nl: "Met geweldige acteurs" },
         performer_type: "happy",
         attendance_mode: "I",
-        legacy_id: "am",
         tagline: { en: "fixing", nl: "repareren" },
         artist: { en: "the", nl: "de" },
         credits: { en: "tests :-)", nl: "testen :-)" },
@@ -265,7 +277,6 @@ describe("ProductionController", () => {
         description2: { en: "With great actors", nl: "Met geweldige acteurs" },
         performer_type: "happy",
         attendance_mode: "I",
-        legacy_id: "am",
         tagline: { en: "fixing", nl: "repareren" },
         artist: { en: "the", nl: "de" },
         credits: { en: "tests :-)", nl: "testen :-)" },

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -27,7 +27,6 @@ describe("ProductionService", () => {
     description2: { en: "With great actors", nl: "Met geweldige acteurs" },
     performer_type: "happy",
     attendance_mode: "I",
-    legacy_id: "am",
     tagline: { en: "fixing", nl: "repareren" },
     artist: { en: "the", nl: "de" },
     credits: { en: "tests :-)", nl: "testen :-)" },
@@ -43,14 +42,12 @@ describe("ProductionService", () => {
       tag: { en: "Drama", nl: "Drama" },
       created_at: "2025-06-01T22:00:00.000Z",
       updated_at: "2025-06-01T22:00:00.000Z",
-      legacy_id: "str",
     },
     {
       id: 2,
       tag: { en: "Classical", nl: "Klassiek" },
       created_at: "2025-06-01T22:00:00.000Z",
       updated_at: "2025-06-01T22:00:00.000Z",
-      legacy_id: "str",
     },
   ];
 
@@ -115,11 +112,21 @@ describe("ProductionService", () => {
     });
 
     it("should return empty array when no productions exist", async () => {
-      jest.spyOn(dbService, "getProductions").mockResolvedValueOnce([]);
+      jest.spyOn(dbService, "getProductions").mockResolvedValueOnce({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
       const result = await service.getAllProductions(
         FilterProductionSchema.parse({}),
       );
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        page: 0,
+        limit: 20,
+        totalItems: 0,
+        objects: [],
+      });
     });
 
     it("should handle database errors", async () => {

--- a/backend/src/production/production.service.spec.ts
+++ b/backend/src/production/production.service.spec.ts
@@ -203,6 +203,7 @@ describe("ProductionService", () => {
 
       expect(dbService.getProductionById).toHaveBeenCalledWith(1);
       expect(dbService.updateProduction).toHaveBeenCalledWith(
+        1,
         expectedMergedProduction,
       );
       expect(result).toEqual(expectedMergedProduction);
@@ -474,7 +475,6 @@ describe("ProductionService", () => {
         description2: { en: "With great actors", nl: "Met geweldige acteurs" },
         performer_type: "happy",
         attendance_mode: "I",
-        legacy_id: "am",
         tagline: { en: "fixing", nl: "repareren" },
         artist: { en: "the", nl: "de" },
         credits: { en: "tests :-)", nl: "testen :-)" },
@@ -507,7 +507,6 @@ describe("ProductionService", () => {
         description2: { en: "With great actors", nl: "Met geweldige acteurs" },
         performer_type: "happy",
         attendance_mode: "I",
-        legacy_id: "am",
         tagline: { en: "fixing", nl: "repareren" },
         artist: { en: "the", nl: "de" },
         credits: { en: "tests :-)", nl: "testen :-)" },

--- a/backend/src/production/production.service.ts
+++ b/backend/src/production/production.service.ts
@@ -76,7 +76,10 @@ export class ProductionService {
       id,
     };
 
-    return await this.productionDBService.updateProduction(mergedProduction);
+    return await this.productionDBService.updateProduction(
+      id,
+      mergedProduction,
+    );
   }
 
   /**

--- a/backend/src/tag/tag.controller.spec.ts
+++ b/backend/src/tag/tag.controller.spec.ts
@@ -27,7 +27,6 @@ describe("TagController", () => {
     },
     created_at: "2024-01-15T19:00:00.000Z",
     updated_at: "2024-01-15T19:00:00.000Z",
-    legacy_id: null,
   };
 
   // What the LanguageService will output
@@ -36,7 +35,6 @@ describe("TagController", () => {
     tag: "Drama",
     created_at: "2024-01-15T19:00:00.000Z",
     updated_at: "2024-01-15T19:00:00Z",
-    legacy_id: null,
   };
 
   const filter: PaginationFilterDto = {
@@ -142,7 +140,6 @@ describe("TagController", () => {
     it("should create and return a new tag", async () => {
       const dto: CreateTagDto = {
         tag: { en: "Action", nl: "Actie" },
-        legacy_id: null,
       };
       const result = await controller.createTag(dto);
 

--- a/backend/src/tag/tag.service.spec.ts
+++ b/backend/src/tag/tag.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { TagService } from "./tag.service";
 import { TagDatabaseService } from "../database/db.tag.service";
-import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { NotFoundException } from "@nestjs/common";
 import {
   CreateTagDto,
   PaginationFilterDto,
@@ -22,7 +22,6 @@ describe("TagService", () => {
     },
     created_at: "2024-01-15T19:00:00.000Z",
     updated_at: "2024-01-15T19:00:00.000Z",
-    legacy_id: null,
   };
 
   const filter: PaginationFilterDto = {
@@ -61,7 +60,6 @@ describe("TagService", () => {
     it("should create and return a new tag", async () => {
       const createDto: CreateTagDto = {
         tag: { en: "NewTag", nl: "NieuweTag" },
-        legacy_id: null,
       };
       const result = await service.createTag(createDto);
       expect(dbService.createTag).toHaveBeenCalledWith(createDto);
@@ -107,18 +105,8 @@ describe("TagService", () => {
         tag: { en: "Updated", nl: "Bijgewerkt" },
       };
       const result = await service.updateTag(1, updateDto);
-      expect(dbService.updateTag).toHaveBeenCalledWith(updateDto);
+      expect(dbService.updateTag).toHaveBeenCalledWith(1, updateDto);
       expect(result).toEqual(mockTag);
-    });
-
-    it("should throw BadRequestException if url id and body id do not match", async () => {
-      const mismatchDto: UpdateTagDto = {
-        id: 2,
-        tag: { en: "Mismatch", nl: "Mismatch" },
-      };
-      await expect(service.updateTag(1, mismatchDto)).rejects.toThrow(
-        BadRequestException,
-      );
     });
   });
 

--- a/backend/src/tag/tag.service.ts
+++ b/backend/src/tag/tag.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { TagDatabaseService } from "../database/db.tag.service";
 import {
   CreateTagDto,
@@ -45,19 +45,13 @@ export class TagService {
   }
 
   /**
-   * Modifies an exising TagDto with the data provided in the body.
+   * Modifies an existing TagDto with the data provided in the body.
    * @param id The ID of the tag.
    * @param updateTag The data we want to update.
    * @returns The newly updated TagDto.
    */
   async updateTag(id: number, updateTag: UpdateTagDto): Promise<TagDto> {
-    if (updateTag.id && updateTag.id !== id) {
-      throw new BadRequestException(
-        "ID in the body does not match ID in the path.",
-      );
-    }
-    // De DatabaseService handelt de merge en update af
-    return await this.dbTagService.updateTag(updateTag);
+    return await this.dbTagService.updateTag(id, updateTag);
   }
 
   /**

--- a/backend/src/util/logger/logger.ts
+++ b/backend/src/util/logger/logger.ts
@@ -1,7 +1,7 @@
 import { createLogger, format, transports, Logger } from "winston";
 import * as dotenv from "dotenv";
 import * as path from "path";
-dotenv.config({ path: path.join(process.cwd(), "../.env") });
+dotenv.config({ path: path.join(process.cwd(), "../.env"), quiet: true });
 
 const { combine, timestamp, printf, colorize, json } = format;
 

--- a/backend/src/util/scraper/inject-csv.ts
+++ b/backend/src/util/scraper/inject-csv.ts
@@ -6,7 +6,7 @@ import { CSVFileParser } from "../../csv_parsing/csv_file_parser";
 import { vnvEvent, vnvGenre, vnvLocation, vnvProduction } from "./vnv.parser";
 
 // Load DEV database env vars for script usage from root .env
-dotenv.config({ path: path.join(process.cwd(), ".env") });
+dotenv.config({ path: path.join(process.cwd(), ".env"), quiet: true });
 
 const DEFAULT_DATE = "1970-01-01T00:00:00+00:00";
 

--- a/backend/src/util/scraper/reset.ts
+++ b/backend/src/util/scraper/reset.ts
@@ -4,7 +4,7 @@ import logger from "../logger/logger";
 // Make sure to execute from the root.
 import * as dotenv from "dotenv";
 import * as path from "path";
-dotenv.config({ path: path.join(process.cwd(), ".env") });
+dotenv.config({ path: path.join(process.cwd(), ".env"), quiet: true });
 
 /**
  * Will remove all data from the database but the leave the tables.

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1193,7 +1193,7 @@ describe("PriceController (e2e)", () => {
     });
   });
 
-  describe("PUT /prices", () => {
+  describe("PATCH /prices/:priceId", () => {
     it("should return 200 with the updated price", () => {
       const updatePayload = {
         id: 1,
@@ -1201,7 +1201,7 @@ describe("PriceController (e2e)", () => {
         name: { en: "Updated", nl: "Bijgewerkt" },
       };
       return request(app.getHttpServer())
-        .put("/prices")
+        .patch("/prices/1")
         .send(updatePayload)
         .expect(200)
         .expect(mockPrice);

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1074,66 +1074,66 @@ describe("EventLocationController (e2e)", () => {
     await app.close();
   });
 
-  describe("GET /events/:eventId/locations", () => {
+  describe("GET /events/:eventId/location", () => {
     it("should return 200 with the flattened location of the event", () => {
       return request(app.getHttpServer())
-        .get("/events/1/locations?lang=en")
+        .get("/events/1/location?lang=en")
         .expect(200)
         .expect(mockLocationView);
     });
 
     it("should call eventDb.getLocationOfEvent with the correct id", async () => {
-      await request(app.getHttpServer()).get("/events/1/locations?lang=en");
+      await request(app.getHttpServer()).get("/events/1/location?lang=en");
       expect(eventDb.getLocationOfEvent).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when eventId is not a number", () => {
       return request(app.getHttpServer())
-        .get("/events/abc/locations")
+        .get("/events/abc/location")
         .expect(400);
     });
   });
 
-  describe("PUT /events/:eventId/locations/:locationId", () => {
+  describe("PUT /events/:eventId/location/:locationId", () => {
     it("should return 200 after successfully linking", () => {
       return request(app.getHttpServer())
-        .put("/events/1/locations/2")
+        .put("/events/1/location/2")
         .expect(200);
     });
 
     it("should call eventDb.linkEventToLocation with correct ids", async () => {
-      await request(app.getHttpServer()).put("/events/1/locations/2");
+      await request(app.getHttpServer()).put("/events/1/location/2");
       expect(eventDb.linkEventToLocation).toHaveBeenCalledWith(1, 2);
     });
 
     it("should return 400 when eventId is not a number", () => {
       return request(app.getHttpServer())
-        .put("/events/abc/locations/1")
+        .put("/events/abc/location/1")
         .expect(400);
     });
 
     it("should return 400 when locationId is not a number", () => {
       return request(app.getHttpServer())
-        .put("/events/1/locations/abc")
+        .put("/events/1/location/abc")
         .expect(400);
     });
   });
 
-  describe("DELETE /events/:eventId/locations", () => {
+  describe("DELETE /events/:eventId/location", () => {
     it("should return 200 after unlinking", () => {
       return request(app.getHttpServer())
-        .delete("/events/1/locations")
+        .delete("/events/1/location")
         .expect(200);
     });
 
     it("should call eventDb.deleteLocationFromEvent with the eventId", async () => {
-      await request(app.getHttpServer()).delete("/events/1/locations");
+      await request(app.getHttpServer()).delete("/events/1/location");
       expect(eventDb.deleteLocationFromEvent).toHaveBeenCalledWith(1);
     });
 
     it("should return 400 when eventId is not a number", () => {
       return request(app.getHttpServer())
-        .delete("/events/abc/locations")
+        .delete("/events/abc/location")
         .expect(400);
     });
   });

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1032,14 +1032,14 @@ describe("LocationController (e2e)", () => {
     });
   });
 
-  describe("PATCH /locations", () => {
+  describe("PATCH /locations/:locationId", () => {
     it("should return 200 with the updated location", () => {
       const updatePayload = {
         id: 1,
         location: { en: "Updated Stage", nl: "Bijgewerkt podium" },
       };
       return request(app.getHttpServer())
-        .patch("/locations")
+        .patch("/locations/1")
         .send(updatePayload)
         .expect(200)
         .expect(mockLocation);

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -54,7 +54,6 @@ const mockBlog2View = {
 const mockTag = {
   id: 1,
   tag: { en: "Drama", nl: "Drama" },
-  legacy_id: "Test Legacy",
   created_at: "2025-06-01T22:00:00.000Z",
   updated_at: "2025-06-01T22:00:00.000Z",
 };
@@ -63,7 +62,6 @@ const mockTagView = { ...mockTag, tag: "Drama" };
 const mockTag2 = {
   id: 2,
   tag: { en: "Comedy", nl: "Komedie" },
-  legacy_id: null,
   created_at: "2025-06-01T22:00:00.000Z",
   updated_at: "2025-06-01T22:00:00.000Z",
 };
@@ -81,7 +79,6 @@ const mockProduction = {
   attendance_mode: "string",
   created_at: "2026-03-07T16:58:08.701Z",
   updated_at: "2026-03-07T16:58:08.701Z",
-  legacy_id: "string",
 };
 const mockProductionView = {
   ...mockProduction,
@@ -99,7 +96,6 @@ const mockEvent = {
   endtime: "2025-01-01T22:00:00.000Z",
   doors_at: "2025-06-01T22:00:00.000Z",
   intermission_at: "2025-06-01T22:00:00.000Z",
-  legacy_id: "string",
   created_at: "2026-03-07T00:00:00.000Z",
   updated_at: "2026-03-07T00:00:00.000Z",
   production_id: 1,
@@ -108,7 +104,6 @@ const mockEvent = {
 const mockLocation = {
   id: 1,
   location: { en: "Main Stage", nl: "Hoofdpodium" },
-  legacy_id: "Test Legacy",
   created_at: "2025-06-01T22:00:00.000Z",
   updated_at: "2025-06-01T22:00:00.000Z",
 };
@@ -118,7 +113,6 @@ const mockPrice = {
   id: 1,
   price: 15.5,
   name: { en: "Early Bird", nl: "Vroege Vogel" },
-  legacy_id: "Test Legacy",
   created_at: "2025-06-01T22:00:00.000Z",
   updated_at: "2025-06-01T22:00:00.000Z",
 };
@@ -339,13 +333,6 @@ describe("BlogController (e2e)", () => {
         .expect(mockBlog);
     });
 
-    it("should return 400 when URL id and body id do not match", () => {
-      return request(app.getHttpServer())
-        .put("/blogs/2")
-        .send(mockBlog)
-        .expect(400);
-    });
-
     it("should return 400 when id param is not a number", () => {
       return request(app.getHttpServer())
         .put("/blogs/abc")
@@ -449,7 +436,6 @@ describe("TagController (e2e)", () => {
   describe("POST /tags", () => {
     const createPayload = {
       tag: { en: "Thriller", nl: "Thriller" },
-      legacy_id: "test",
     };
 
     it("should return 201 with the created tag", () => {
@@ -477,13 +463,6 @@ describe("TagController (e2e)", () => {
         .send({ tag: { en: "Thriller", nl: "Thriller" } })
         .expect(200)
         .expect(mockTag);
-    });
-
-    it("should return 400 when body id does not match URL id", () => {
-      return request(app.getHttpServer())
-        .patch("/tags/1")
-        .send({ id: 99, tag: { en: "Other", nl: "Ander" } })
-        .expect(400);
     });
 
     it("should return 400 when id is not a number", () => {
@@ -573,7 +552,6 @@ describe("ProductionController (e2e)", () => {
       titel: { en: "New Production", nl: "Nieuwe Productie" },
       description1: { en: "Desc 1", nl: "Beschrijving 1" },
       description2: { en: "Desc 2", nl: "Beschrijving 2" },
-      legacy_id: "etst",
       attendance_mode: "etst",
       performer_type: "etst",
       tagline: { en: "test", nl: "test" },
@@ -896,7 +874,6 @@ describe("EventController (e2e)", () => {
       starttime: "2025-06-01T19:00:00.000Z",
       endtime: "2025-06-01T22:00:00.000Z",
       production_id: 1,
-      legacy_id: "1",
       doors_at: "2025-06-01T22:00:00.000Z",
       intermission_at: "2025-06-01T22:00:00.000Z",
     };

--- a/common/src/objects/blogs.ts
+++ b/common/src/objects/blogs.ts
@@ -18,7 +18,11 @@ export const CreateBlogSchema = BlogSchema.omit({
   created_at: true,
   updated_at: true,
 });
-export const UpdateBlogSchema = BlogSchema.partial();
+export const UpdateBlogSchema = BlogSchema.partial().omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
 
 export type Blog = z.infer<typeof BlogSchema>;
 export type BlogView = z.infer<typeof BlogViewSchema>;

--- a/common/src/objects/events.ts
+++ b/common/src/objects/events.ts
@@ -17,7 +17,11 @@ export const CreateEventSchema = EventSchema.omit({
   created_at: true,
   updated_at: true,
 });
-export const UpdateEventSchema = EventSchema.partial();
+export const UpdateEventSchema = EventSchema.partial().omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
 
 export const FilterEventSchema = z.object({
   date: z.iso.date().optional(),

--- a/common/src/objects/events.ts
+++ b/common/src/objects/events.ts
@@ -9,7 +9,7 @@ export const EventSchema = z.object({
   created_at: z.iso.datetime(),
   updated_at: z.iso.datetime(),
   production_id: z.number(),
-  legacy_id: z.string().nullable(),
+  // Legacy ID is omitted here because the API doesn't use it.
 });
 
 export const CreateEventSchema = EventSchema.omit({

--- a/common/src/objects/locations.ts
+++ b/common/src/objects/locations.ts
@@ -6,7 +6,7 @@ export const LocationSchema = z.object({
   location: LocalizedStringSchema,
   created_at: z.iso.datetime(),
   updated_at: z.iso.datetime(),
-  legacy_id: z.string().nullable(),
+  // Legacy ID is omitted here because the API doesn't use it.
 });
 export const LocationViewSchema = LocationSchema.extend({
   location: z.string(),

--- a/common/src/objects/locations.ts
+++ b/common/src/objects/locations.ts
@@ -17,7 +17,11 @@ export const CreateLocationSchema = LocationSchema.omit({
   created_at: true,
   updated_at: true,
 });
-export const UpdateLocationSchema = LocationSchema.partial();
+export const UpdateLocationSchema = LocationSchema.partial().omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
 
 export type Location = z.infer<typeof LocationSchema>;
 export type LocationView = z.infer<typeof LocationViewSchema>;

--- a/common/src/objects/prices.ts
+++ b/common/src/objects/prices.ts
@@ -7,7 +7,7 @@ export const PriceSchema = z.object({
   name: LocalizedStringSchema,
   created_at: z.iso.datetime(),
   updated_at: z.iso.datetime(),
-  legacy_id: z.string().nullable(),
+  // Legacy ID is omitted here because the API doesn't use it.
 });
 export const PriceViewSchema = PriceSchema.extend({
   name: z.string(),

--- a/common/src/objects/prices.ts
+++ b/common/src/objects/prices.ts
@@ -18,7 +18,11 @@ export const CreatePriceSchema = PriceSchema.omit({
   created_at: true,
   updated_at: true,
 });
-export const UpdatePriceSchema = PriceSchema.partial();
+export const UpdatePriceSchema = PriceSchema.partial().omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
 
 export type Price = z.infer<typeof PriceSchema>;
 export type PriceView = z.infer<typeof PriceViewSchema>;

--- a/common/src/objects/productions.ts
+++ b/common/src/objects/productions.ts
@@ -32,7 +32,11 @@ export const CreateProductionSchema = ProductionSchema.omit({
   created_at: true,
   updated_at: true,
 });
-export const UpdateProductionSchema = ProductionSchema.partial();
+export const UpdateProductionSchema = ProductionSchema.partial().omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
 
 export const FilterProductionSchema = z.object({
   lang: LanguageEnum.optional(),

--- a/common/src/objects/productions.ts
+++ b/common/src/objects/productions.ts
@@ -17,7 +17,7 @@ export const ProductionSchema = z.object({
   attendance_mode: z.string().nullable(),
   created_at: z.iso.datetime().nullable(), // TODO remove nullable when update csv parser bcs otherwise doesnt work.
   updated_at: z.iso.datetime().nullable(), // TODO here too.
-  legacy_id: z.string().nullable(),
+  // Legacy ID is omitted here because the API doesn't use it.
 });
 export const ProductionViewSchema = ProductionSchema.extend({
   titel: z.string(),

--- a/common/src/objects/tags.ts
+++ b/common/src/objects/tags.ts
@@ -6,7 +6,7 @@ export const TagSchema = z.object({
   tag: LocalizedStringSchema,
   created_at: z.iso.datetime(),
   updated_at: z.iso.datetime(),
-  legacy_id: z.string().nullable(),
+  // Legacy ID is omitted here because the API doesn't use it.
 });
 export const TagViewSchema = TagSchema.extend({
   tag: z.string(),

--- a/common/src/objects/tags.ts
+++ b/common/src/objects/tags.ts
@@ -17,7 +17,11 @@ export const CreateTagSchema = TagSchema.omit({
   created_at: true,
   updated_at: true,
 });
-export const UpdateTagSchema = TagSchema.partial();
+export const UpdateTagSchema = TagSchema.partial().omit({
+  id: true,
+  created_at: true,
+  updated_at: true,
+});
 
 export type Tag = z.infer<typeof TagSchema>;
 export type TagView = z.infer<typeof TagViewSchema>;

--- a/frontend/app/composables/useLocationApi.ts
+++ b/frontend/app/composables/useLocationApi.ts
@@ -36,9 +36,9 @@ export function useLocationApi() {
   const create = (body: CreateLocation) =>
     post<Location, CreateLocation>(API_ROUTES.locations.base, body);
 
-  /** PATCH /locations — updates an existing location. The ID must be included in the body. */
-  const modify = (body: UpdateLocation) =>
-    patch<Location, UpdateLocation>(API_ROUTES.locations.base, body);
+  /** PATCH /locations — updates an existing location. */
+  const modify = (locationId: number, body: UpdateLocation) =>
+    patch<Location, UpdateLocation>(API_ROUTES.locations.byId(locationId), body);
 
   /** DELETE /locations/:locationId — deletes a location. */
   const remove = (locationId: number) =>

--- a/frontend/app/composables/usePriceApi.ts
+++ b/frontend/app/composables/usePriceApi.ts
@@ -38,7 +38,6 @@ export function usePriceApi() {
 
   /**
    * PATCH /prices/:priceId — fully replaces an existing price.
-   * The ID must be included in the body (no ID in the URL for this endpoint).
    */
   const replace = (priceId: number, body: UpdatePrice) =>
     patch<Price, UpdatePrice>(API_ROUTES.prices.byId(priceId), body);

--- a/frontend/app/composables/usePriceApi.ts
+++ b/frontend/app/composables/usePriceApi.ts
@@ -17,7 +17,7 @@ import { API_ROUTES } from "../utils/apiRoutes";
  * the full localized object (Price). Without a lang, the raw localized object is returned.
  */
 export function usePriceApi() {
-  const { get, post, put, del } = useApi();
+  const { get, post, patch, del } = useApi();
 
   /** GET /prices — returns a paginated list of prices. */
   const getAll = (pagination?: Partial<PaginationFilter>, lang?: Language) => {
@@ -37,11 +37,11 @@ export function usePriceApi() {
     post<Price, CreatePrice>(API_ROUTES.prices.base, body);
 
   /**
-   * PUT /prices — fully replaces an existing price.
+   * PATCH /prices/:priceId — fully replaces an existing price.
    * The ID must be included in the body (no ID in the URL for this endpoint).
    */
-  const replace = (body: UpdatePrice) =>
-    put<Price, UpdatePrice>(API_ROUTES.prices.base, body);
+  const replace = (priceId: number, body: UpdatePrice) =>
+    patch<Price, UpdatePrice>(API_ROUTES.prices.byId(priceId), body);
 
   /** DELETE /prices/:priceId — deletes a price. */
   const remove = (priceId: number) =>

--- a/frontend/app/utils/apiRoutes.ts
+++ b/frontend/app/utils/apiRoutes.ts
@@ -21,8 +21,8 @@ export const API_ROUTES = {
   events: {
     base: "/events",
     byId: (eventId: number) => `/events/${eventId}`,
-    locations: (eventId: number) => `/events/${eventId}/locations`,
-    locationById: (eventId: number, locationId: number) => `/events/${eventId}/locations/${locationId}`,
+    locations: (eventId: number) => `/events/${eventId}/location`,
+    locationById: (eventId: number, locationId: number) => `/events/${eventId}/location/${locationId}`,
     prices: (eventId: number) => `/events/${eventId}/prices`,
     priceById: (eventId: number, priceId: number) => `/events/${eventId}/prices/${priceId}`,
   },

--- a/frontend/tests/composables/useEventApi.spec.ts
+++ b/frontend/tests/composables/useEventApi.spec.ts
@@ -62,29 +62,29 @@ describe("useEventApi", () => {
     expect(mockDel).toHaveBeenCalledWith("/events/1");
   });
 
-  describe("locations", () => {
-    it("getLocation calls GET /events/:id/locations", () => {
+  describe("location", () => {
+    it("getLocation calls GET /events/:id/location", () => {
       const { getLocation } = useEventApi();
       getLocation(1);
-      expect(mockGet).toHaveBeenCalledWith("/events/1/locations");
+      expect(mockGet).toHaveBeenCalledWith("/events/1/location");
     });
 
     it("getLocation appends lang param", () => {
       const { getLocation } = useEventApi();
       getLocation(1, "nl");
-      expect(mockGet).toHaveBeenCalledWith("/events/1/locations?lang=nl");
+      expect(mockGet).toHaveBeenCalledWith("/events/1/location?lang=nl");
     });
 
-    it("linkLocation calls PUT /events/:id/locations/:locationId", () => {
+    it("linkLocation calls PUT /events/:id/location/:locationId", () => {
       const { linkLocation } = useEventApi();
       linkLocation(1, 2);
-      expect(mockPut).toHaveBeenCalledWith("/events/1/locations/2", {});
+      expect(mockPut).toHaveBeenCalledWith("/events/1/location/2", {});
     });
 
-    it("unlinkLocation calls DELETE /events/:id/locations", () => {
+    it("unlinkLocation calls DELETE /events/:id/location", () => {
       const { unlinkLocation } = useEventApi();
       unlinkLocation(1);
-      expect(mockDel).toHaveBeenCalledWith("/events/1/locations");
+      expect(mockDel).toHaveBeenCalledWith("/events/1/location");
     });
   });
 

--- a/frontend/tests/composables/useLocationApi.spec.ts
+++ b/frontend/tests/composables/useLocationApi.spec.ts
@@ -55,10 +55,10 @@ describe("useLocationApi", () => {
     expect(mockPost).toHaveBeenCalledWith("/locations", body);
   });
 
-  it("modify calls PATCH /locations with body", () => {
+  it("modify calls PATCH /locations/:id with body", () => {
     const { modify } = useLocationApi();
-    modify({ id: 1, location: { nl: "Brugge", en: "Brugge" } });
-    expect(mockPatch).toHaveBeenCalledWith("/locations", { id: 1, location: { nl: "Brugge", en: "Brugge" } });
+    modify(1, { id: 1, location: { nl: "Brugge", en: "Brugge" } });
+    expect(mockPatch).toHaveBeenCalledWith("/locations/1", { id: 1, location: { nl: "Brugge", en: "Brugge" } });
   });
 
   it("remove calls DELETE /locations/:id", () => {

--- a/frontend/tests/composables/usePriceApi.spec.ts
+++ b/frontend/tests/composables/usePriceApi.spec.ts
@@ -3,11 +3,11 @@ import { usePriceApi } from "../../app/composables/usePriceApi";
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
-const mockPut = vi.fn();
+const mockPatch = vi.fn();
 const mockDel = vi.fn();
 
 vi.mock("~/composables/useApi", () => ({
-  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut, del: mockDel }),
+  useApi: () => ({ get: mockGet, post: mockPost, patch: mockPatch, del: mockDel }),
 }));
 
 beforeEach(() => {
@@ -55,11 +55,11 @@ describe("usePriceApi", () => {
     expect(mockPost).toHaveBeenCalledWith("/prices", body);
   });
 
-  it("replace calls PUT /prices with body", () => {
+  it("replace calls PATCH /prices/:priceId with body", () => {
     const { replace } = usePriceApi();
     const body = { id: 1, price: 15.0, name: { nl: "Aangepast", en: "Updated" } };
-    replace(body);
-    expect(mockPut).toHaveBeenCalledWith("/prices", body);
+    replace(1, body);
+    expect(mockPatch).toHaveBeenCalledWith("/prices/1", body);
   });
 
   it("remove calls DELETE /prices/:id", () => {


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] This PR cleans up the backend significantly and streamlines the design.

#### Changelog

* Changed PUT to PATCH for price and added ":priceId" at the end of the URL.
* Added ":locationId" at the end of the URL for PATCH to locations. 
* Changed "locations" to "location" for event locations to amplify the belief that there is one location only per event. 
* Updated all UpdateXDto objects to not include the meta fields like ID (now you HAVE to pass it in the URL not the body)
* Removed `legacy_id` from being visible in API objects. This is something solely used for parser/scraper purposes and thus does not need to be available through the API.

#### Fixed Bugs

* Fixed a bug where mandatory fields weren't being passed to Event CREATE.
* Fixed a bug where mandatory fields weren't being passed to Price CREATE.
 
## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

Tests are being updated as I go and currently all work correctly.

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code

Docs are also updated as we go.

## 🔍 HOW TO TEST

Go onto the Swagger docs and test everything out, you can also run the test command.

## ✅ CLOSED ISSUES
- Closes #233 