### PR TITLE
Date Ordering + Reverse for Blogs

### DIFF
--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -236,7 +236,7 @@ describe("AuthGuards tests", () => {
   describe("Blog endpoints authentication", () => {
     it("GET /blogs should work without API key", async () => {
       await request(app.getHttpServer())
-        .get("/blogs")
+        .get("/blogs?descending=true")
         .expect((res) => {
           expect([200, 410]).toContain(res.status);
         });

--- a/backend/src/blog/blog.controller.ts
+++ b/backend/src/blog/blog.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  ParseBoolPipe,
   ParseIntPipe,
   Patch,
   Post,
@@ -53,6 +54,7 @@ export class BlogController {
    * Responds to a GET to "/blogs"
    * @param lang is the language filter
    * @param paginationFilter is the pagination params
+   * @param descending Whether the list of blogs will be descending in date.
    * @returns A list of all Blog objects.
    */
   @ApiOperation({ summary: "Returns all blogs." })
@@ -62,8 +64,12 @@ export class BlogController {
     @Query(new ZodValidationPipe(LanguageQuerySchema)) lang: LanguageQueryDto,
     @Query(new ZodValidationPipe(PaginationFilterSchema))
     paginationFilter: PaginationFilterDto,
+    @Query("descending", ParseBoolPipe) descending: boolean,
   ): Promise<PaginatedResponse<BlogDto | BlogViewDto>> {
-    const result = await this.blogService.getAllBlogs(paginationFilter);
+    const result = await this.blogService.getAllBlogs(
+      paginationFilter,
+      descending,
+    );
     return this.ls.flattenByLanguage<PaginatedResponse<BlogDto | BlogViewDto>>(
       result,
       lang.lang,

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -19,10 +19,12 @@ export class BlogService {
    */
   async getAllBlogs(
     paginationFilter: PaginationFilterDto,
+    descending: boolean,
   ): Promise<PaginatedResponse<BlogDto>> {
     return await this.blogDbService.getBlogs(
       paginationFilter.limit,
       paginationFilter.page,
+      descending,
     );
   }
 

--- a/backend/src/blog/blog.service.ts
+++ b/backend/src/blog/blog.service.ts
@@ -14,7 +14,8 @@ export class BlogService {
 
   /**
    * Gets all Blogs from the DatabaseService.
-   * @param paginationFilter iq the pagination params.
+   * @param paginationFilter is the pagination params.
+   * @param descending Whether the blogs should be sorted descending or ascending.
    * @returns A list of all Blog objects.
    */
   async getAllBlogs(

--- a/backend/src/database/db.blog.service.ts
+++ b/backend/src/database/db.blog.service.ts
@@ -34,11 +34,13 @@ export class BlogDatabaseService {
    * Get blogs with pagination
    * @param amount number of blogs per page (if amount=0, it will default to grabbing all blogs)
    * @param page page index (starts at 0)
+   * @param descending Whether the dates should be sorted descending or ascending.
    * @returns blogs
    */
   async getBlogs(
     amount: number = 0,
     page: number = 0,
+    descending: boolean = true,
   ): Promise<PaginatedResponse<BlogDto>> {
     const offset = page * amount;
     const countResult = await this.db.query<{ count: string }>(
@@ -52,7 +54,7 @@ export class BlogDatabaseService {
              created_at,
              updated_at
       FROM blogs
-      ORDER BY id
+      ORDER BY created_at ${descending ? "DESC" : "ASC"}
       `;
 
       return {
@@ -70,7 +72,7 @@ export class BlogDatabaseService {
            created_at,
            updated_at
     FROM blogs
-    ORDER BY id
+    ORDER BY created_at ${descending ? "DESC" : "ASC"}
     LIMIT $1 OFFSET $2
     `;
 

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -253,20 +253,20 @@ describe("BlogController (e2e)", () => {
   describe("GET /blogs", () => {
     it("should return 200 with an array of flattened blogs", () => {
       return request(app.getHttpServer())
-        .get("/blogs?lang=en")
+        .get("/blogs?lang=en&descending=true")
         .expect(200)
         .expect([mockBlogView, mockBlog2View]);
     });
 
     it("should call blogDb.getBlogs()", async () => {
-      await request(app.getHttpServer()).get("/blogs?lang=en");
+      await request(app.getHttpServer()).get("/blogs?lang=en&descending=true");
       expect(blogDb.getBlogs).toHaveBeenCalled();
     });
 
     it("should return 200 with an empty array when no blogs exist", async () => {
       jest.spyOn(blogDb, "getBlogs").mockResolvedValueOnce([]);
       return request(app.getHttpServer())
-        .get("/blogs?lang=en")
+        .get("/blogs?lang=en&descending=true")
         .expect(200)
         .expect([]);
     });

--- a/frontend/app/composables/useBlogApi.ts
+++ b/frontend/app/composables/useBlogApi.ts
@@ -23,7 +23,7 @@ export function useBlogApi() {
   const getAll = (
     pagination?: Partial<PaginationFilter>,
     lang?: Language,
-    descending: boolean = true, // Defaults to descending for bog timeline.
+    descending: boolean = true, // Defaults to descending for blog timeline.
   ) => {
     const params = {
       ...pagination,

--- a/frontend/app/composables/useBlogApi.ts
+++ b/frontend/app/composables/useBlogApi.ts
@@ -20,10 +20,18 @@ export function useBlogApi() {
   const { get, post, put, patch, del } = useApi();
 
   /** GET /blogs — returns a paginated list of blogs. */
-  const getAll = (pagination?: Partial<PaginationFilter>, lang?: Language) => {
-    const params = { ...pagination, ...(lang ? { lang } : {}) };
+  const getAll = (
+    pagination?: Partial<PaginationFilter>,
+    lang?: Language,
+    descending: boolean = true, // Defaults to descending for bog timeline.
+  ) => {
+    const params = {
+      ...pagination,
+      ...(lang ? { lang } : {}),
+      ...{ descending: descending },
+    };
     const query = Object.keys(params).length
-      ? "?" + new URLSearchParams(params as Record<string, string>).toString()
+      ? "?" + new URLSearchParams(params as Record<string, any>).toString()
       : "";
     return get<PaginatedResponse<Blog | BlogView>>(
       `${API_ROUTES.blogs.base}${query}`,

--- a/frontend/tests/composables/useBlogApi.spec.ts
+++ b/frontend/tests/composables/useBlogApi.spec.ts
@@ -8,7 +8,13 @@ const mockPatch = vi.fn();
 const mockDel = vi.fn();
 
 vi.mock("~/composables/useApi", () => ({
-  useApi: () => ({ get: mockGet, post: mockPost, put: mockPut, patch: mockPatch, del: mockDel }),
+  useApi: () => ({
+    get: mockGet,
+    post: mockPost,
+    put: mockPut,
+    patch: mockPatch,
+    del: mockDel,
+  }),
 }));
 
 beforeEach(() => {
@@ -30,11 +36,12 @@ describe("useBlogApi", () => {
 
   it("getAll appends pagination and lang together", () => {
     const { getAll } = useBlogApi();
-    getAll({ page: 0, limit: 5 }, "nl");
+    getAll({ page: 0, limit: 5 }, "nl", true);
     const url = mockGet.mock.calls[0][0];
     expect(url).toContain("page=0");
     expect(url).toContain("limit=5");
     expect(url).toContain("lang=nl");
+    expect(url).toContain("descending=true");
   });
 
   it("getById calls GET /blogs/:id", () => {

--- a/frontend/tests/composables/useBlogApi.spec.ts
+++ b/frontend/tests/composables/useBlogApi.spec.ts
@@ -25,7 +25,7 @@ describe("useBlogApi", () => {
   it("getAll calls GET /blogs", () => {
     const { getAll } = useBlogApi();
     getAll();
-    expect(mockGet).toHaveBeenCalledWith("/blogs");
+    expect(mockGet).toHaveBeenCalledWith("/blogs?descending=true");
   });
 
   it("getAll appends lang query param", () => {


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature

* Adds a `descending` boolean that needs to be passed to the `/blogs` endpoint as a Query parameter. In the Frontend the `useBlogApi` hook uses `true` by default but can be changed.

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION

**Missing documentation:**
* I will update endpoint documentation when the backend is definitively done, for now this is out of scope and I want to keep this PR straight to the point.

## 🔍 HOW TO TEST

Go to Swagger and the blogs endpoint, you'll see a new mandatory option there that will prompt you if you want a `descending` ordered list or not. You can see the order being swapped in the list you recieve.

## 📸 SCREENSHOTS (if necessary):

<img width="765" height="644" alt="image" src="https://github.com/user-attachments/assets/2240f8d0-033d-414a-b47a-80efbc0aff4d" />

## ✅ CLOSED ISSUES
- Closes #242 
