### PR TITLE
Parser service into module + translations

### DIFF
--- a/backend/src/csv_parsing/csv_file_parser.spec.ts
+++ b/backend/src/csv_parsing/csv_file_parser.spec.ts
@@ -103,24 +103,6 @@ describe("CSVFileParser", () => {
       });
     });
 
-    it("should handle missing English location with Dutch fallback", () => {
-      const row = {
-        ID: "1",
-        Starttime: "2024-01-01 10:00:00",
-        Endtime: "2024-01-01 12:00:00",
-        Production: "5",
-        Location_NL: "Nederlandse Zaal",
-        Location_EN: "",
-      };
-
-      const result = CSVFileParser.transformEventRow(row);
-
-      expect(result.location).toEqual({
-        en: "Nederlandse Zaal",
-        nl: "Nederlandse Zaal",
-      });
-    });
-
     it("should set endtime to null for invalid or empty endtime", () => {
       const row = {
         ID: "1",

--- a/backend/src/csv_parsing/csv_file_parser.ts
+++ b/backend/src/csv_parsing/csv_file_parser.ts
@@ -75,8 +75,8 @@ export class CSVFileParser {
     }
 
     if (!en && nl) {
-      //TODO translate
-      return { en: nl, nl };
+      //translating will be done before inserting
+      return { en: "", nl };
     }
 
     return { en, nl };

--- a/backend/src/util/scraper/csv-injection.service.ts
+++ b/backend/src/util/scraper/csv-injection.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from "@nestjs/common";
+import { UtilsDbConnection } from "./database/db.connection";
+import {
+  injectBlogsCSV,
+  injectEventsCSV,
+  injectOldCsvData,
+  injectPricesCSV,
+  injectProductionsCSV,
+  injectTagsCSV,
+} from "./inject-csv";
+
+@Injectable()
+export class CsvInjectionService {
+  constructor(private readonly dbConnection: UtilsDbConnection) {}
+
+  async injectProductionsCSV(filePath: string) {
+    return injectProductionsCSV(filePath, this.dbConnection);
+  }
+
+  async injectEventsCSV(filePath: string) {
+    return injectEventsCSV(filePath, this.dbConnection);
+  }
+
+  async injectTagsCSV(filePath: string) {
+    return injectTagsCSV(filePath, this.dbConnection);
+  }
+
+  async injectBlogsCSV(filePath: string) {
+    return injectBlogsCSV(filePath, this.dbConnection);
+  }
+
+  async injectPricesCSV(filePath: string) {
+    return injectPricesCSV(filePath, this.dbConnection);
+  }
+
+  async injectOldCsvData() {
+    return injectOldCsvData(this.dbConnection);
+  }
+}

--- a/backend/src/util/scraper/inject-csv.spec.ts
+++ b/backend/src/util/scraper/inject-csv.spec.ts
@@ -10,6 +10,7 @@ const mockLogger = {
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
+  debug: jest.fn(),
 };
 
 jest.mock("../../csv_parsing/csv_file_parser", () => ({

--- a/backend/src/util/scraper/inject-csv.ts
+++ b/backend/src/util/scraper/inject-csv.ts
@@ -44,14 +44,27 @@ function getLanguageService(): LanguageService | null {
 async function translateBeforeInsert<T>(data: T): Promise<T> {
   const translator = getLanguageService();
   if (!translator) {
+    logger.debug(
+      `[translation] skipped (${TRANSLATION_LANG_FROM} -> ${TRANSLATION_LANG_TO}) because translator is unavailable`,
+    );
     return data;
   }
 
-  return translator.translateObject<T>(
+  logger.debug(
+    `[translation] started (${TRANSLATION_LANG_FROM} -> ${TRANSLATION_LANG_TO})`,
+  );
+
+  const translated = await translator.translateObject<T>(
     data,
     TRANSLATION_LANG_FROM,
     TRANSLATION_LANG_TO,
   );
+
+  logger.debug(
+    `[translation] finished (${TRANSLATION_LANG_FROM} -> ${TRANSLATION_LANG_TO})`,
+  );
+
+  return translated;
 }
 
 function toOldCsvTag(tagName: string): vnvGenre {

--- a/backend/src/util/scraper/inject-csv.ts
+++ b/backend/src/util/scraper/inject-csv.ts
@@ -131,8 +131,10 @@ function toCsvProduction(row: {
  * Import only productions from the structured CSV.
  * Can be run independently from other imports.
  */
-export async function injectProductionsCSV(filePath: string) {
-  const dbConnection = new UtilsDbConnection();
+export async function injectProductionsCSV(
+  filePath: string,
+  dbConnection: UtilsDbConnection = new UtilsDbConnection(),
+) {
   logger.info(`Parsing productions CSV: ${filePath}`);
 
   const parsedProductions = await CSVFileParser.parseProductionsCSV(filePath);
@@ -152,8 +154,10 @@ export async function injectProductionsCSV(filePath: string) {
  * Import only events (+ locations) from the structured CSV.
  * Can be run independently from other imports.
  */
-export async function injectEventsCSV(filePath: string) {
-  const dbConnection = new UtilsDbConnection();
+export async function injectEventsCSV(
+  filePath: string,
+  dbConnection: UtilsDbConnection = new UtilsDbConnection(),
+) {
   logger.info(`Parsing events CSV: ${filePath}`);
 
   const parsedEvents = await CSVFileParser.parseEventsCSV(filePath);
@@ -192,8 +196,10 @@ export async function injectEventsCSV(filePath: string) {
  * Import only tags from the structured CSV and link them to already existing productions.
  * Can be run independently from other imports.
  */
-export async function injectTagsCSV(filePath: string) {
-  const dbConnection = new UtilsDbConnection();
+export async function injectTagsCSV(
+  filePath: string,
+  dbConnection: UtilsDbConnection = new UtilsDbConnection(),
+) {
   logger.info(`Parsing tags CSV: ${filePath}`);
 
   const parsedTags = await CSVFileParser.parseTagsCSV(filePath);
@@ -229,8 +235,10 @@ export async function injectTagsCSV(filePath: string) {
  * Import only blogs from the structured CSV and link them to already existing productions.
  * Can be run independently from other imports.
  */
-export async function injectBlogsCSV(filePath: string) {
-  const dbConnection = new UtilsDbConnection();
+export async function injectBlogsCSV(
+  filePath: string,
+  dbConnection: UtilsDbConnection = new UtilsDbConnection(),
+) {
   logger.info(`Parsing blogs CSV: ${filePath}`);
 
   const parsedBlogs = await CSVFileParser.parseBlogsCSV(filePath);
@@ -261,8 +269,10 @@ export async function injectBlogsCSV(filePath: string) {
  * Import only prices from the structured CSV and link them to already existing events.
  * Can be run independently from other imports.
  */
-export async function injectPricesCSV(filePath: string) {
-  const dbConnection = new UtilsDbConnection();
+export async function injectPricesCSV(
+  filePath: string,
+  dbConnection: UtilsDbConnection = new UtilsDbConnection(),
+) {
   logger.info(`Parsing prices CSV: ${filePath}`);
 
   const parsedPrices = await CSVFileParser.parsePricesCSV(filePath);
@@ -291,9 +301,9 @@ export async function injectPricesCSV(filePath: string) {
   logger.info("Structured prices CSV injection completed.");
 }
 
-export async function injectOldCsvData() {
-  const dbConnection = new UtilsDbConnection();
-
+export async function injectOldCsvData(
+  dbConnection: UtilsDbConnection = new UtilsDbConnection(),
+) {
   const productionsFile = "../common/res/productions_output.csv";
   const eventsFile = "../common/res/events_voorstellingen.csv";
 

--- a/backend/src/util/scraper/inject-csv.ts
+++ b/backend/src/util/scraper/inject-csv.ts
@@ -59,7 +59,7 @@ function toOldCsvTag(tagName: string): vnvGenre {
     legacy_id: `csv-${tagName}`,
     created_at: DEFAULT_DATE,
     updated_at: DEFAULT_DATE,
-    name: { en: tagName, nl: tagName }, //TODO translate with Google Translate API
+    name: { en: "", nl: tagName },
   };
 }
 
@@ -68,7 +68,7 @@ function toOldCsvLocation(locationName: string): vnvLocation {
     legacy_id: `csv-${locationName}`,
     created_at: DEFAULT_DATE,
     updated_at: DEFAULT_DATE,
-    name: { en: locationName, nl: locationName }, //TODO translate with Google Translate API
+    name: { en: "", nl: locationName },
   };
 }
 

--- a/backend/src/util/scraper/inject-csv.ts
+++ b/backend/src/util/scraper/inject-csv.ts
@@ -2,14 +2,57 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 import { UtilsDbConnection } from "./database/db.connection";
 import logger from "../logger/logger";
+import { AppLogger } from "../logger/logger.service";
+import { LanguageService } from "../language/language.service";
 import { OldCSVFileParser } from "../../csv_parsing/old_csv_file_parser";
 import { CSVFileParser } from "../../csv_parsing/csv_file_parser";
 import { vnvEvent, vnvGenre, vnvLocation, vnvProduction } from "./vnv.parser";
+import { Language } from "@repo/common";
 
 // Load DEV database env vars for script usage from root .env
 dotenv.config({ path: path.join(process.cwd(), ".env"), quiet: true });
 
 const DEFAULT_DATE = "1970-01-01T00:00:00+00:00";
+const TRANSLATION_LANG_FROM: Language = "nl";
+const TRANSLATION_LANG_TO: Language = "en";
+
+let languageService: LanguageService | null = null;
+
+function getLanguageService(): LanguageService | null {
+  if (languageService) {
+    return languageService;
+  }
+
+  if (!process.env.TRANSLATE_API_KEY) {
+    logger.warn(
+      "TRANSLATE_API_KEY is not set; CSV injection will continue without DeepL translation.",
+    );
+    return null;
+  }
+
+  try {
+    languageService = new LanguageService(logger as unknown as AppLogger);
+    return languageService;
+  } catch (error) {
+    logger.warn(
+      `Failed to initialize LanguageService; continuing without translation: ${String(error)}`,
+    );
+    return null;
+  }
+}
+
+async function translateBeforeInsert<T>(data: T): Promise<T> {
+  const translator = getLanguageService();
+  if (!translator) {
+    return data;
+  }
+
+  return translator.translateObject<T>(
+    data,
+    TRANSLATION_LANG_FROM,
+    TRANSLATION_LANG_TO,
+  );
+}
 
 function toOldCsvTag(tagName: string): vnvGenre {
   return {
@@ -146,7 +189,10 @@ export async function injectProductionsCSV(
     }),
   );
 
-  await dbConnection.insertProductions(csvProductions);
+  const translatedProductions =
+    await translateBeforeInsert<vnvProduction[]>(csvProductions);
+
+  await dbConnection.insertProductions(translatedProductions);
   logger.info("Structured productions CSV injection completed.");
 }
 
@@ -173,7 +219,10 @@ export async function injectEventsCSV(
 
   const csvLocations: vnvLocation[] = Array.from(locationByName.values());
 
-  await dbConnection.insertLocations(csvLocations);
+  const translatedLocations =
+    await translateBeforeInsert<vnvLocation[]>(csvLocations);
+
+  await dbConnection.insertLocations(translatedLocations);
 
   // Now that locations are inserted, we can convert events to csvEvents with locationLegacyIds
   const csvEvents: vnvEvent[] = parsedEvents.map((row) => {
@@ -188,7 +237,9 @@ export async function injectEventsCSV(
     });
   });
 
-  await dbConnection.insertEvents(csvEvents);
+  const translatedEvents = await translateBeforeInsert<vnvEvent[]>(csvEvents);
+
+  await dbConnection.insertEvents(translatedEvents);
   logger.info("Structured events CSV injection completed.");
 }
 
@@ -205,13 +256,15 @@ export async function injectTagsCSV(
   const parsedTags = await CSVFileParser.parseTagsCSV(filePath);
 
   for (const row of parsedTags) {
-    const tagLegacyId = "csv-" + row.tag.tag.nl;
+    const translatedTagData = await translateBeforeInsert(row.tag);
+
+    const tagLegacyId = "csv-" + translatedTagData.tag.nl;
 
     const tagId = await dbConnection.insertTag({
       legacy_id: tagLegacyId,
       created_at: DEFAULT_DATE,
       updated_at: DEFAULT_DATE,
-      name: row.tag.tag,
+      name: translatedTagData.tag,
     });
 
     for (const productionId of row.productionIds) {
@@ -244,14 +297,16 @@ export async function injectBlogsCSV(
   const parsedBlogs = await CSVFileParser.parseBlogsCSV(filePath);
 
   for (const row of parsedBlogs) {
+    const translatedBlogRow = await translateBeforeInsert(row);
+
     const productionLegacyId = toCsvLegacyIdFromNumericId(row.production_id);
     try {
       const production =
         await dbConnection.getProductionByLegacyId(productionLegacyId);
 
       const blog = await dbConnection.insertBlog(
-        row.blog.titel,
-        row.blog.description,
+        translatedBlogRow.blog.titel,
+        translatedBlogRow.blog.description,
       );
 
       await dbConnection.linkBlog(production.id, blog.id);
@@ -278,18 +333,20 @@ export async function injectPricesCSV(
   const parsedPrices = await CSVFileParser.parsePricesCSV(filePath);
 
   for (const row of parsedPrices) {
+    const translatedPriceData = await translateBeforeInsert(row.price);
+
     const eventLegacyId = toCsvLegacyIdFromNumericId(row.event_id);
     try {
       const event = await dbConnection.getEventByLegacyId(eventLegacyId);
 
-      const priceLegacyId = "csv-" + row.price.name.nl;
+      const priceLegacyId = "csv-" + translatedPriceData.name.nl;
 
       const price = await dbConnection.insertPrice({
         legacy_id: priceLegacyId,
         created_at: DEFAULT_DATE,
         updated_at: DEFAULT_DATE,
-        amount: row.price.price,
-        name: row.price.name,
+        amount: translatedPriceData.price,
+        name: translatedPriceData.name,
       });
 
       await dbConnection.linkPrice(event.id, price.id);
@@ -333,17 +390,24 @@ export async function injectOldCsvData(
     toOldCsvEvent(row.event, index, row.location.trim()),
   );
 
+  const translatedTags = await translateBeforeInsert<vnvGenre[]>(csvTags);
+  const translatedLocations =
+    await translateBeforeInsert<vnvLocation[]>(csvLocations);
+  const translatedProductions =
+    await translateBeforeInsert<vnvProduction[]>(csvProductions);
+  const translatedEvents = await translateBeforeInsert<vnvEvent[]>(csvEvents);
+
   logger.info(
     "Injecting CSV data into DEV database using DbConnection insert functions...",
   );
 
   await Promise.all([
-    dbConnection.insertTags(csvTags),
-    dbConnection.insertLocations(csvLocations),
+    dbConnection.insertTags(translatedTags),
+    dbConnection.insertLocations(translatedLocations),
   ]);
 
-  await dbConnection.insertProductions(csvProductions);
-  await dbConnection.insertEvents(csvEvents);
+  await dbConnection.insertProductions(translatedProductions);
+  await dbConnection.insertEvents(translatedEvents);
 
   logger.info("CSV injection completed.");
 }

--- a/backend/src/util/scraper/scraper.module.ts
+++ b/backend/src/util/scraper/scraper.module.ts
@@ -5,9 +5,15 @@ import { ScraperRunner } from "./main";
 import { LanguageModule } from "../language/LanguageModule";
 import { LoggerModule } from "../logger/logger.module";
 import { ScraperDbModule } from "./database/scraper.db.module";
+import { CsvInjectionService } from "./csv-injection.service";
 
 @Module({
-  providers: [ScraperService, ScraperEngine, ScraperRunner],
+  providers: [
+    ScraperService,
+    ScraperEngine,
+    ScraperRunner,
+    CsvInjectionService,
+  ],
   exports: [ScraperEngine, ScraperRunner, ScraperService],
   imports: [LanguageModule, LoggerModule, ScraperDbModule],
 })

--- a/backend/src/util/scraper/scraper.service.ts
+++ b/backend/src/util/scraper/scraper.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, OnApplicationBootstrap } from "@nestjs/common";
-import { injectOldCsvData } from "./inject-csv";
 import { AppLogger } from "../logger/logger.service";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { ScraperRunner } from "./main";
+import { CsvInjectionService } from "./csv-injection.service";
 
 /**
  * Service that handles the scraping of data and injecting of it into the database.
@@ -12,6 +12,7 @@ export class ScraperService implements OnApplicationBootstrap {
   constructor(
     private readonly logger: AppLogger,
     private readonly runner: ScraperRunner,
+    private readonly csvInjectionService: CsvInjectionService,
   ) {}
 
   /**
@@ -33,7 +34,8 @@ export class ScraperService implements OnApplicationBootstrap {
     }
 
     this.logger.log("Running initial CSV injection...");
-    injectOldCsvData()
+    this.csvInjectionService
+      .injectOldCsvData()
       .then(() => {
         this.logger.log(
           "Initial CSV injection finished successfully.",


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature
* make a service for the csv-parser so i can put it in a module.
* do translations for csv data before inserting

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code

## 🔍 HOW TO TEST
There is not much to test.
You can try to wipe the DB and run the inject script for the test files and see if they get translated correctly, but this would use our limit of the translator which is not recommended :)

## ⚠️ REMAINING ISSUES
- [x] this code requires changes elsewhere (changed database structure, API-endpoint, etc.)
* I still need to create some kind of endpoint do the frontend can acces the parser.

## 📸 SCREENSHOTS (if necessary):

## ✅ CLOSED ISSUES
- Closes #250 
