### PR TITLE
Tests for media endpoints

### DIFF
--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -126,7 +126,7 @@ describe("AuthGuards tests", () => {
     });
 
     it("GET /productions/:id should work without API key", async () => {
-      const response = await request(app.getHttpServer())
+      await request(app.getHttpServer())
         .get("/productions/1")
         .send({})
         .expect((res) => {
@@ -348,6 +348,165 @@ describe("AuthGuards tests", () => {
 
     it("DELETE /auth/:accountId should fail without API key.", async () => {
       await request(app.getHttpServer()).delete("/auth/1").expect(401);
+    });
+  });
+
+  describe("Media Crop endpoints authentication", () => {
+    it("GET /media/crops should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/crops")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("GET /media/crops/:cropId should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/crops/1")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("POST /media/crops should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .post("/media/crops")
+        .send({})
+        .expect(401);
+    });
+
+    it("PUT /media/crops/:cropId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .put("/media/crops/1")
+        .send({})
+        .expect(401);
+    });
+
+    it("PATCH /media/crops/:cropId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .patch("/media/crops/1")
+        .send({})
+        .expect(401);
+    });
+
+    it("DELETE /media/crops/:cropId should fail without API key", async () => {
+      await request(app.getHttpServer()).delete("/media/crops/1").expect(401);
+    });
+  });
+
+  describe("Media Item endpoints authentication", () => {
+    it("GET /media/items should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/items")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("GET /media/items/:itemId should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/items/1")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("POST /media/items should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .post("/media/items")
+        .send({})
+        .expect(401);
+    });
+
+    it("PUT /media/items/:itemId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .put("/media/items/1")
+        .send({})
+        .expect(401);
+    });
+
+    it("PATCH /media/items/:itemId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .patch("/media/items/1")
+        .send({})
+        .expect(401);
+    });
+
+    it("DELETE /media/items/:itemId should fail without API key", async () => {
+      await request(app.getHttpServer()).delete("/media/items/1").expect(401);
+    });
+
+    // Item <-> Crop relationship auth
+    it("GET /media/items/:itemId/crops should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/items/1/crops")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("PUT /media/items/:itemId/crops/:cropId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .put("/media/items/1/crops/1")
+        .expect(401);
+    });
+
+    it("DELETE /media/items/:itemId/crops/:cropId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .delete("/media/items/1/crops/1")
+        .expect(401);
+    });
+  });
+
+  describe("Media Gallery endpoints authentication", () => {
+    it("GET /media/galleries should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/galleries")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("GET /media/galleries/:galleryId should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/galleries/1")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("POST /media/galleries should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .post("/media/galleries")
+        .send({})
+        .expect(401);
+    });
+
+    it("DELETE /media/galleries/:galleryId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .delete("/media/galleries/1")
+        .expect(401);
+    });
+
+    // Gallery <-> Item relationship auth
+    it("GET /media/galleries/:galleryId/items should work without API key", async () => {
+      await request(app.getHttpServer())
+        .get("/media/galleries/1/items")
+        .expect((res) => {
+          expect([200, 410]).toContain(res.status);
+        });
+    });
+
+    it("PUT /media/galleries/:galleryId/items/:itemId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .put("/media/galleries/1/items/1")
+        .expect(401);
+    });
+
+    it("DELETE /media/galleries/:galleryId/items/:itemId should fail without API key", async () => {
+      await request(app.getHttpServer())
+        .delete("/media/galleries/1/items/1")
+        .expect(401);
     });
   });
 });

--- a/backend/src/media/controllers/media.crop.controller.spec.ts
+++ b/backend/src/media/controllers/media.crop.controller.spec.ts
@@ -1,0 +1,154 @@
+// media.crop.controller.spec.ts
+import { Test, TestingModule } from "@nestjs/testing";
+import { MediaCropController } from "./media.crop.controller";
+import { MediaCropService } from "../services/media.crop.service";
+import { PaginatedResponse } from "@repo/common";
+import {
+  CreateMediaCropDto,
+  MediaCropDto,
+  ModifyMediaCropDto,
+  ReplaceMediaCropDto,
+  PaginationFilterDto,
+} from "../../dto/dto";
+import { ApiKeyGuard } from "../../auth/authGuard";
+
+describe("MediaCropController", () => {
+  let controller: MediaCropController;
+  let mediaCropService: jest.Mocked<MediaCropService>;
+
+  const mockCrop: MediaCropDto = {
+    id: 1,
+    name: "hd_ready",
+    url: "https://example.com/crop.jpg",
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  beforeEach(async () => {
+    const mockMediaCropService = {
+      getCrops: jest.fn(),
+      getCropById: jest.fn(),
+      createCrop: jest.fn(),
+      replaceCrop: jest.fn(),
+      modifyCrop: jest.fn(),
+      deleteCrop: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MediaCropController],
+      providers: [
+        {
+          provide: MediaCropService,
+          useValue: mockMediaCropService,
+        },
+      ],
+    })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({
+        canActivate: jest.fn(() => true),
+      })
+      .compile();
+
+    controller = module.get<MediaCropController>(MediaCropController);
+    mediaCropService = module.get(MediaCropService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("getCrops", () => {
+    it("should return a paginated list of crops", async () => {
+      const paginationFilters: PaginationFilterDto = {
+        page: 1,
+        limit: 10,
+        descending: true,
+      };
+      const expectedResponse: PaginatedResponse<MediaCropDto> = {
+        objects: [mockCrop],
+        totalItems: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      mediaCropService.getCrops.mockResolvedValue(expectedResponse);
+
+      const result = await controller.getCrops(paginationFilters);
+
+      expect(mediaCropService.getCrops).toHaveBeenCalledWith(paginationFilters);
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe("getCropById", () => {
+    it("should return a single crop", async () => {
+      mediaCropService.getCropById.mockResolvedValue(mockCrop);
+
+      const result = await controller.getCropById(1);
+
+      expect(mediaCropService.getCropById).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("createCrop", () => {
+    it("should create and return a new crop", async () => {
+      const createCropDto: CreateMediaCropDto = {
+        name: "FE3_header",
+        url: "https://example.com/header.jpg",
+        item_id: 12,
+      };
+      mediaCropService.createCrop.mockResolvedValue(mockCrop);
+
+      const result = await controller.createCrop(createCropDto);
+
+      expect(mediaCropService.createCrop).toHaveBeenCalledWith(createCropDto);
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("replaceCrop", () => {
+    it("should replace and return the crop", async () => {
+      const replaceCropDto: ReplaceMediaCropDto = {
+        name: "og_image",
+        url: "https://example.com/og.jpg",
+      };
+      mediaCropService.replaceCrop.mockResolvedValue(mockCrop);
+
+      const result = await controller.replaceCrop(1, replaceCropDto);
+
+      expect(mediaCropService.replaceCrop).toHaveBeenCalledWith(
+        1,
+        replaceCropDto,
+      );
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("modifyCrop", () => {
+    it("should modify and return the crop", async () => {
+      const modifyCropDto: ModifyMediaCropDto = {
+        url: "https://example.com/patched.jpg",
+      };
+      mediaCropService.modifyCrop.mockResolvedValue(mockCrop);
+
+      const result = await controller.modifyCrop(1, modifyCropDto);
+
+      expect(mediaCropService.modifyCrop).toHaveBeenCalledWith(
+        1,
+        modifyCropDto,
+      );
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("deleteCrop", () => {
+    it("should delete the crop", async () => {
+      mediaCropService.deleteCrop.mockResolvedValue(undefined);
+
+      await controller.deleteCrop(1);
+
+      expect(mediaCropService.deleteCrop).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/backend/src/media/controllers/media.gallery.controller.spec.ts
+++ b/backend/src/media/controllers/media.gallery.controller.spec.ts
@@ -1,0 +1,165 @@
+// media.gallery.controller.spec.ts
+import { Test, TestingModule } from "@nestjs/testing";
+import { MediaGalleryController } from "./media.gallery.controller";
+import { MediaGalleryService } from "../services/media.gallery.service";
+import { ApiKeyGuard } from "../../auth/authGuard";
+import { PaginatedResponse } from "@repo/common";
+import {
+  CreateMediaGalleryDto,
+  MediaGalleryDto,
+  MediaItemDto,
+  PaginationFilterDto,
+} from "../../dto/dto";
+
+describe("MediaGalleryController", () => {
+  let controller: MediaGalleryController;
+  let mediaGalleryService: jest.Mocked<MediaGalleryService>;
+
+  const mockGallery: MediaGalleryDto = {
+    id: 1,
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  const mockItem: MediaItemDto = {
+    id: 1,
+    type: "image",
+    original_filename: "test.png",
+    position: "main",
+    width: 1920,
+    height: 1080,
+    title: { en: "Vid Title", nl: "Vid Title" },
+    description: { en: "Vid Desc", nl: "Vid Desc" },
+    credits: { en: "Vid Credits", nl: "Vid Credits" },
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  beforeEach(async () => {
+    const mockMediaGalleryService = {
+      getGalleries: jest.fn(),
+      getGalleryById: jest.fn(),
+      createGallery: jest.fn(),
+      deleteGallery: jest.fn(),
+      getGalleryItems: jest.fn(),
+      linkItemToGallery: jest.fn(),
+      unlinkItemFromGallery: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MediaGalleryController],
+      providers: [
+        {
+          provide: MediaGalleryService,
+          useValue: mockMediaGalleryService,
+        },
+      ],
+    })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({
+        canActivate: jest.fn(() => true),
+      })
+      .compile();
+
+    controller = module.get<MediaGalleryController>(MediaGalleryController);
+    mediaGalleryService = module.get(MediaGalleryService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("getGalleries", () => {
+    it("should return a paginated list of galleries", async () => {
+      const paginationFilter: PaginationFilterDto = {
+        page: 1,
+        limit: 10,
+        descending: true,
+      };
+      const expectedResponse: PaginatedResponse<MediaGalleryDto> = {
+        objects: [mockGallery],
+        totalItems: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      mediaGalleryService.getGalleries.mockResolvedValue(expectedResponse);
+
+      const result = await controller.getGalleries(paginationFilter);
+
+      expect(mediaGalleryService.getGalleries).toHaveBeenCalledWith(
+        paginationFilter,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe("getGalleryById", () => {
+    it("should return a single gallery", async () => {
+      mediaGalleryService.getGalleryById.mockResolvedValue(mockGallery);
+
+      const result = await controller.getGalleryById(1);
+
+      expect(mediaGalleryService.getGalleryById).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockGallery);
+    });
+  });
+
+  describe("createGallery", () => {
+    it("should create and return a new gallery", async () => {
+      const createGalleryDto: CreateMediaGalleryDto = {};
+      mediaGalleryService.createGallery.mockResolvedValue(mockGallery);
+
+      const result = await controller.createGallery(createGalleryDto);
+
+      expect(mediaGalleryService.createGallery).toHaveBeenCalledWith(
+        createGalleryDto,
+      );
+      expect(result).toEqual(mockGallery);
+    });
+  });
+
+  describe("deleteGallery", () => {
+    it("should delete the gallery", async () => {
+      mediaGalleryService.deleteGallery.mockResolvedValue(undefined);
+
+      await controller.deleteGallery(1);
+
+      expect(mediaGalleryService.deleteGallery).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("getGalleryItems", () => {
+    it("should return all items for a gallery", async () => {
+      mediaGalleryService.getGalleryItems.mockResolvedValue([mockItem]);
+
+      const result = await controller.getGalleryItems(1);
+
+      expect(mediaGalleryService.getGalleryItems).toHaveBeenCalledWith(1);
+      expect(result).toEqual([mockItem]);
+    });
+  });
+
+  describe("linkItemToGallery", () => {
+    it("should link an item to a gallery", async () => {
+      mediaGalleryService.linkItemToGallery.mockResolvedValue(undefined);
+
+      await controller.linkItemToGallery(1, 2);
+
+      expect(mediaGalleryService.linkItemToGallery).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
+  describe("unlinkItemFromGallery", () => {
+    it("should unlink an item from a gallery", async () => {
+      mediaGalleryService.unlinkItemFromGallery.mockResolvedValue(undefined);
+
+      await controller.unlinkItemFromGallery(1, 2);
+
+      expect(mediaGalleryService.unlinkItemFromGallery).toHaveBeenCalledWith(
+        1,
+        2,
+      );
+    });
+  });
+});

--- a/backend/src/media/controllers/media.item.controller.spec.ts
+++ b/backend/src/media/controllers/media.item.controller.spec.ts
@@ -1,0 +1,247 @@
+// media.item.controller.spec.ts
+import { Test, TestingModule } from "@nestjs/testing";
+import { MediaItemController } from "./media.item.controller";
+import { MediaItemService } from "../services/media.item.service";
+import { LanguageService } from "../../util/language/language.service";
+import { ApiKeyGuard } from "../../auth/authGuard";
+import { PaginatedResponse } from "@repo/common";
+import {
+  CreateMediaItemDto,
+  MediaItemDto,
+  MediaItemViewDto,
+  ModifyMediaItemDto,
+  ReplaceMediaItemDto,
+  PaginationFilterDto,
+  LanguageQueryDto,
+  MediaCropDto,
+} from "../../dto/dto";
+
+describe("MediaItemController", () => {
+  let controller: MediaItemController;
+  let mediaItemService: jest.Mocked<MediaItemService>;
+  let languageService: jest.Mocked<LanguageService>;
+
+  const mockItem: MediaItemDto = {
+    id: 1,
+    type: "image",
+    original_filename: "test.png",
+    position: "main",
+    width: 1920,
+    height: 1080,
+    title: { en: "Vid Title", nl: "Vid Title" },
+    description: { en: "Vid Desc", nl: "Vid Desc" },
+    credits: { en: "Vid Credits", nl: "Vid Credits" },
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  const mockItemView: MediaItemViewDto = {
+    ...mockItem,
+    title: "Title",
+    description: "Desc",
+    credits: "Credits",
+  };
+
+  beforeEach(async () => {
+    const mockMediaItemService = {
+      getItems: jest.fn(),
+      getItemById: jest.fn(),
+      createItem: jest.fn(),
+      replaceItem: jest.fn(),
+      modifyItem: jest.fn(),
+      deleteItem: jest.fn(),
+      getItemCrops: jest.fn(),
+      linkCropToItem: jest.fn(),
+      unlinkCropFromItem: jest.fn(),
+    };
+
+    const mockLanguageService = {
+      flattenByLanguage: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MediaItemController],
+      providers: [
+        {
+          provide: MediaItemService,
+          useValue: mockMediaItemService,
+        },
+        {
+          provide: LanguageService,
+          useValue: mockLanguageService,
+        },
+      ],
+    })
+      .overrideGuard(ApiKeyGuard)
+      .useValue({
+        canActivate: jest.fn(() => true),
+      })
+      .compile();
+
+    controller = module.get<MediaItemController>(MediaItemController);
+    mediaItemService = module.get(MediaItemService);
+    languageService = module.get(LanguageService);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe("getItems", () => {
+    it("should fetch, flatten, and return a paginated list of items", async () => {
+      const paginationFilter: PaginationFilterDto = {
+        page: 1,
+        limit: 10,
+        descending: true,
+      };
+      const langQuery: LanguageQueryDto = { lang: "en" };
+      const paginatedItems: PaginatedResponse<MediaItemDto> = {
+        objects: [mockItem],
+        totalItems: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      const expectedFlattened: PaginatedResponse<MediaItemViewDto> = {
+        ...paginatedItems,
+        objects: [mockItemView],
+      };
+
+      mediaItemService.getItems.mockResolvedValue(paginatedItems);
+      languageService.flattenByLanguage.mockReturnValue(
+        expectedFlattened as any,
+      );
+
+      const result = await controller.getItems(paginationFilter, langQuery);
+
+      expect(mediaItemService.getItems).toHaveBeenCalledWith(paginationFilter);
+      expect(languageService.flattenByLanguage).toHaveBeenCalledWith(
+        paginatedItems,
+        "en",
+      );
+      expect(result).toEqual(expectedFlattened);
+    });
+  });
+
+  describe("getItemById", () => {
+    it("should fetch, flatten, and return a single item", async () => {
+      const langQuery: LanguageQueryDto = { lang: "en" };
+
+      mediaItemService.getItemById.mockResolvedValue(mockItem);
+      languageService.flattenByLanguage.mockReturnValue(mockItemView as any);
+
+      const result = await controller.getItemById(1, langQuery);
+
+      expect(mediaItemService.getItemById).toHaveBeenCalledWith(1);
+      expect(languageService.flattenByLanguage).toHaveBeenCalledWith(
+        mockItem,
+        "en",
+      );
+      expect(result).toEqual(mockItemView);
+    });
+  });
+
+  describe("createItem", () => {
+    it("should create and return a new item", async () => {
+      const createItemDto: CreateMediaItemDto = {
+        type: "image",
+        original_filename: "test.png",
+        position: "main",
+        width: 1920,
+        height: 1080,
+        title: { en: "Vid Title", nl: "Vid Title" },
+        description: { en: "Vid Desc", nl: "Vid Desc" },
+        credits: { en: "Vid Credits", nl: "Vid Credits" },
+      };
+      mediaItemService.createItem.mockResolvedValue(mockItem);
+
+      const result = await controller.createItem(createItemDto);
+
+      expect(mediaItemService.createItem).toHaveBeenCalledWith(createItemDto);
+      expect(result).toEqual(mockItem);
+    });
+  });
+
+  describe("replaceItem", () => {
+    it("should replace and return the item", async () => {
+      const replaceItemDto: ReplaceMediaItemDto = {
+        type: "image",
+        original_filename: "test.png",
+        position: "main",
+        width: 1920,
+        height: 1080,
+        title: { en: "Vid Title", nl: "Vid Title" },
+        description: { en: "Vid Desc", nl: "Vid Desc" },
+        credits: { en: "Vid Credits", nl: "Vid Credits" },
+      };
+      mediaItemService.replaceItem.mockResolvedValue(mockItem);
+
+      const result = await controller.replaceItem(1, replaceItemDto);
+
+      expect(mediaItemService.replaceItem).toHaveBeenCalledWith(
+        1,
+        replaceItemDto,
+      );
+      expect(result).toEqual(mockItem);
+    });
+  });
+
+  describe("modifyItem", () => {
+    it("should modify and return the item", async () => {
+      const modifyItemDto: ModifyMediaItemDto = { position: "carousel" };
+      mediaItemService.modifyItem.mockResolvedValue(mockItem);
+
+      const result = await controller.modifyItem(1, modifyItemDto);
+
+      expect(mediaItemService.modifyItem).toHaveBeenCalledWith(
+        1,
+        modifyItemDto,
+      );
+      expect(result).toEqual(mockItem);
+    });
+  });
+
+  describe("deleteItem", () => {
+    it("should delete the item", async () => {
+      mediaItemService.deleteItem.mockResolvedValue(undefined);
+
+      await controller.deleteItem(1);
+
+      expect(mediaItemService.deleteItem).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("getItemCrops", () => {
+    it("should return all crops for an item", async () => {
+      const mockCrops: MediaCropDto[] = [
+        { id: 1, name: "hd_ready" } as MediaCropDto,
+      ];
+      mediaItemService.getItemCrops.mockResolvedValue(mockCrops);
+
+      const result = await controller.getItemCrops(1);
+
+      expect(mediaItemService.getItemCrops).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockCrops);
+    });
+  });
+
+  describe("linkCropToItem", () => {
+    it("should link a crop to an item", async () => {
+      mediaItemService.linkCropToItem.mockResolvedValue(undefined);
+
+      await controller.linkCropToItem(1, 2);
+
+      expect(mediaItemService.linkCropToItem).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
+  describe("unlinkCropFromItem", () => {
+    it("should unlink a crop from an item", async () => {
+      mediaItemService.unlinkCropFromItem.mockResolvedValue(undefined);
+
+      await controller.unlinkCropFromItem(1, 2);
+
+      expect(mediaItemService.unlinkCropFromItem).toHaveBeenCalledWith(1, 2);
+    });
+  });
+});

--- a/backend/src/media/services/media.crop.service.spec.ts
+++ b/backend/src/media/services/media.crop.service.spec.ts
@@ -1,0 +1,163 @@
+// media.crop.service.spec.ts
+import { Test, TestingModule } from "@nestjs/testing";
+import { MediaCropService } from "./media.crop.service";
+import { MediaDatabaseService } from "../../database/db.media.service";
+import { PaginatedResponse } from "@repo/common";
+import {
+  CreateMediaCropDto,
+  MediaCropDto,
+  ModifyMediaCropDto,
+  ReplaceMediaCropDto,
+  PaginationFilterDto,
+} from "../../dto/dto";
+
+describe("MediaCropService", () => {
+  let service: MediaCropService;
+  let mediaDbService: jest.Mocked<MediaDatabaseService>;
+
+  const mockCrop: MediaCropDto = {
+    id: 1,
+    name: "hd_ready",
+    url: "https://example.com/crop.jpg",
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  beforeEach(async () => {
+    const mockMediaDbService = {
+      getAllCrops: jest.fn(),
+      getCropById: jest.fn(),
+      createCrop: jest.fn(),
+      updateCrop: jest.fn(),
+      deleteCrop: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaCropService,
+        {
+          provide: MediaDatabaseService,
+          useValue: mockMediaDbService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MediaCropService>(MediaCropService);
+    mediaDbService = module.get(MediaDatabaseService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("getCrops", () => {
+    it("should return a paginated list of crops", async () => {
+      const paginationFilters: PaginationFilterDto = {
+        page: 1,
+        limit: 10,
+        descending: true,
+      };
+      const expectedResponse: PaginatedResponse<MediaCropDto> = {
+        objects: [mockCrop],
+        totalItems: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      mediaDbService.getAllCrops.mockResolvedValue(expectedResponse);
+
+      const result = await service.getCrops(paginationFilters);
+
+      expect(mediaDbService.getAllCrops).toHaveBeenCalledWith(
+        paginationFilters,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe("getCropById", () => {
+    it("should return a single crop", async () => {
+      mediaDbService.getCropById.mockResolvedValue(mockCrop);
+
+      const result = await service.getCropById(1);
+
+      expect(mediaDbService.getCropById).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("createCrop", () => {
+    it("should create and return a new crop", async () => {
+      const createCropDto: CreateMediaCropDto = {
+        name: "thumbnail",
+        url: "https://example.com/thumb.jpg",
+        item_id: 42,
+      };
+      mediaDbService.createCrop.mockResolvedValue(mockCrop);
+
+      const result = await service.createCrop(createCropDto);
+
+      expect(mediaDbService.createCrop).toHaveBeenCalledWith(createCropDto);
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("replaceCrop", () => {
+    it("should replace and return the crop", async () => {
+      const replaceCropDto: ReplaceMediaCropDto = {
+        name: "mobile",
+        url: "https://example.com/mobile.jpg",
+      };
+      mediaDbService.updateCrop.mockResolvedValue(mockCrop);
+
+      const result = await service.replaceCrop(1, replaceCropDto);
+
+      expect(mediaDbService.updateCrop).toHaveBeenCalledWith(1, replaceCropDto);
+      expect(result).toEqual(mockCrop);
+    });
+  });
+
+  describe("modifyCrop", () => {
+    it("should fetch the existing crop, merge modifications, and update", async () => {
+      const existingCrop: MediaCropDto = {
+        id: 1,
+        name: "hd_ready",
+        url: "https://example.com/old.jpg",
+        created_at: "2026-03-28T14:00:00.000Z",
+        updated_at: "2026-03-28T14:00:00.000Z",
+      };
+
+      const modifyCropDto: ModifyMediaCropDto = {
+        url: "https://example.com/new.jpg",
+      };
+
+      const expectedMergedCrop: MediaCropDto = {
+        ...existingCrop,
+        ...modifyCropDto,
+        id: 1,
+      };
+
+      mediaDbService.getCropById.mockResolvedValue(existingCrop);
+      mediaDbService.updateCrop.mockResolvedValue(expectedMergedCrop);
+
+      const result = await service.modifyCrop(1, modifyCropDto);
+
+      expect(mediaDbService.getCropById).toHaveBeenCalledWith(1);
+      expect(mediaDbService.updateCrop).toHaveBeenCalledWith(
+        1,
+        expectedMergedCrop,
+      );
+      expect(result).toEqual(expectedMergedCrop);
+    });
+  });
+
+  describe("deleteCrop", () => {
+    it("should delete the crop", async () => {
+      mediaDbService.deleteCrop.mockResolvedValue(undefined);
+
+      await service.deleteCrop(1);
+
+      expect(mediaDbService.deleteCrop).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/backend/src/media/services/media.gallery.service.spec.ts
+++ b/backend/src/media/services/media.gallery.service.spec.ts
@@ -1,0 +1,158 @@
+// media.gallery.service.spec.ts
+import { Test, TestingModule } from "@nestjs/testing";
+import { MediaGalleryService } from "./media.gallery.service";
+import { MediaDatabaseService } from "../../database/db.media.service";
+import { PaginatedResponse } from "@repo/common";
+import {
+  CreateMediaGalleryDto,
+  MediaGalleryDto,
+  MediaItemDto,
+  PaginationFilterDto,
+} from "../../dto/dto";
+
+describe("MediaGalleryService", () => {
+  let service: MediaGalleryService;
+  let mediaDbService: jest.Mocked<MediaDatabaseService>;
+
+  const mockGallery: MediaGalleryDto = {
+    id: 1,
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  const mockItem: MediaItemDto = {
+    id: 1,
+    type: "image",
+    original_filename: "test.png",
+    position: "main",
+    width: 1920,
+    height: 1080,
+    title: { en: "Vid Title", nl: "Vid Title" },
+    description: { en: "Vid Desc", nl: "Vid Desc" },
+    credits: { en: "Vid Credits", nl: "Vid Credits" },
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  beforeEach(async () => {
+    const mockMediaDbService = {
+      getGalleries: jest.fn(),
+      getGalleryById: jest.fn(),
+      createGallery: jest.fn(),
+      deleteGallery: jest.fn(),
+      getItemsByGallery: jest.fn(),
+      linkItemToGallery: jest.fn(),
+      unlinkItemFromGallery: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaGalleryService,
+        {
+          provide: MediaDatabaseService,
+          useValue: mockMediaDbService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MediaGalleryService>(MediaGalleryService);
+    mediaDbService = module.get(MediaDatabaseService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("getGalleries", () => {
+    it("should return a paginated list of galleries", async () => {
+      const paginationFilter: PaginationFilterDto = {
+        page: 1,
+        limit: 10,
+        descending: true,
+      };
+      const expectedResponse: PaginatedResponse<MediaGalleryDto> = {
+        objects: [mockGallery],
+        totalItems: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      mediaDbService.getGalleries.mockResolvedValue(expectedResponse);
+
+      const result = await service.getGalleries(paginationFilter);
+
+      // Note: The service unpacks the DTO properties to pass to the DB service
+      expect(mediaDbService.getGalleries).toHaveBeenCalledWith(
+        paginationFilter.limit,
+        paginationFilter.page,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe("getGalleryById", () => {
+    it("should return a single gallery", async () => {
+      mediaDbService.getGalleryById.mockResolvedValue(mockGallery);
+
+      const result = await service.getGalleryById(1);
+
+      expect(mediaDbService.getGalleryById).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockGallery);
+    });
+  });
+
+  describe("createGallery", () => {
+    it("should create and return a new gallery", async () => {
+      const createGalleryDto: CreateMediaGalleryDto = {};
+      mediaDbService.createGallery.mockResolvedValue(mockGallery);
+
+      const result = await service.createGallery(createGalleryDto);
+
+      expect(mediaDbService.createGallery).toHaveBeenCalledWith(
+        createGalleryDto,
+      );
+      expect(result).toEqual(mockGallery);
+    });
+  });
+
+  describe("deleteGallery", () => {
+    it("should delete the gallery", async () => {
+      mediaDbService.deleteGallery.mockResolvedValue(undefined);
+
+      await service.deleteGallery(1);
+
+      expect(mediaDbService.deleteGallery).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("getGalleryItems", () => {
+    it("should return all items for a gallery", async () => {
+      mediaDbService.getItemsByGallery.mockResolvedValue([mockItem]);
+
+      const result = await service.getGalleryItems(1);
+
+      expect(mediaDbService.getItemsByGallery).toHaveBeenCalledWith(1);
+      expect(result).toEqual([mockItem]);
+    });
+  });
+
+  describe("linkItemToGallery", () => {
+    it("should link an item to a gallery", async () => {
+      mediaDbService.linkItemToGallery.mockResolvedValue(undefined);
+
+      await service.linkItemToGallery(1, 2);
+
+      expect(mediaDbService.linkItemToGallery).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
+  describe("unlinkItemFromGallery", () => {
+    it("should unlink an item from a gallery", async () => {
+      mediaDbService.unlinkItemFromGallery.mockResolvedValue(undefined);
+
+      await service.unlinkItemFromGallery(1, 2);
+
+      expect(mediaDbService.unlinkItemFromGallery).toHaveBeenCalledWith(1, 2);
+    });
+  });
+});

--- a/backend/src/media/services/media.item.service.spec.ts
+++ b/backend/src/media/services/media.item.service.spec.ts
@@ -1,0 +1,236 @@
+// media.item.service.spec.ts
+import { Test, TestingModule } from "@nestjs/testing";
+import { MediaItemService } from "./media.item.service";
+import { MediaDatabaseService } from "../../database/db.media.service";
+import { PaginatedResponse } from "@repo/common";
+import {
+  CreateMediaItemDto,
+  MediaItemDto,
+  ModifyMediaItemDto,
+  ReplaceMediaItemDto,
+  PaginationFilterDto,
+  MediaCropDto,
+} from "../../dto/dto";
+
+describe("MediaItemService", () => {
+  let service: MediaItemService;
+  let mediaDbService: jest.Mocked<MediaDatabaseService>;
+
+  const mockItem: MediaItemDto = {
+    id: 1,
+    type: "image",
+    original_filename: "test-image.png",
+    position: "main",
+    width: 1920,
+    height: 1080,
+    title: { en: "Vid Title", nl: "Vid Title" },
+    description: { en: "Vid Desc", nl: "Vid Desc" },
+    credits: { en: "Vid Credits", nl: "Vid Credits" },
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  const mockCrop: MediaCropDto = {
+    id: 1,
+    name: "hd_ready",
+    url: "https://example.com/crop.jpg",
+    created_at: "2026-03-28T14:00:00.000Z",
+    updated_at: "2026-03-28T14:00:00.000Z",
+  };
+
+  beforeEach(async () => {
+    const mockMediaDbService = {
+      getAllItems: jest.fn(),
+      getItemById: jest.fn(),
+      createItem: jest.fn(),
+      updateItem: jest.fn(),
+      deleteItem: jest.fn(),
+      getCropsByItem: jest.fn(),
+      linkCropToItem: jest.fn(),
+      unlinkCropFromItem: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MediaItemService,
+        {
+          provide: MediaDatabaseService,
+          useValue: mockMediaDbService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MediaItemService>(MediaItemService);
+    mediaDbService = module.get(MediaDatabaseService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("getItems", () => {
+    it("should return a paginated list of items", async () => {
+      const paginationFilters: PaginationFilterDto = {
+        page: 1,
+        limit: 10,
+        descending: true,
+      };
+      const expectedResponse: PaginatedResponse<MediaItemDto> = {
+        objects: [mockItem],
+        totalItems: 1,
+        page: 1,
+        limit: 10,
+      };
+
+      mediaDbService.getAllItems.mockResolvedValue(expectedResponse);
+
+      const result = await service.getItems(paginationFilters);
+
+      expect(mediaDbService.getAllItems).toHaveBeenCalledWith(
+        paginationFilters,
+      );
+      expect(result).toEqual(expectedResponse);
+    });
+  });
+
+  describe("getItemById", () => {
+    it("should return a single item", async () => {
+      mediaDbService.getItemById.mockResolvedValue(mockItem);
+
+      const result = await service.getItemById(1);
+
+      expect(mediaDbService.getItemById).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockItem);
+    });
+  });
+
+  describe("createItem", () => {
+    it("should create an item with gallery_ids", async () => {
+      const createItemDto: CreateMediaItemDto = {
+        type: "image",
+        original_filename: "new.png",
+        position: "carousel",
+        width: 800,
+        height: 600,
+        title: { en: "Vid Title", nl: "Vid Title" },
+        description: { en: "Vid Desc", nl: "Vid Desc" },
+        credits: { en: "Vid Credits", nl: "Vid Credits" },
+        gallery_ids: [1, 2],
+      };
+      mediaDbService.createItem.mockResolvedValue(mockItem);
+
+      const result = await service.createItem(createItemDto);
+
+      expect(mediaDbService.createItem).toHaveBeenCalledWith(
+        createItemDto,
+        [1, 2],
+      );
+      expect(result).toEqual(mockItem);
+    });
+
+    it("should default to empty array if gallery_ids are missing", async () => {
+      const createItemDto: CreateMediaItemDto = {
+        type: "image",
+        original_filename: "new.png",
+        position: "carousel",
+        width: 800,
+        height: 600,
+        title: { en: "Vid Title", nl: "Vid Title" },
+        description: { en: "Vid Desc", nl: "Vid Desc" },
+        credits: { en: "Vid Credits", nl: "Vid Credits" },
+      };
+      mediaDbService.createItem.mockResolvedValue(mockItem);
+
+      const result = await service.createItem(createItemDto);
+
+      expect(mediaDbService.createItem).toHaveBeenCalledWith(createItemDto, []);
+      expect(result).toEqual(mockItem);
+    });
+  });
+
+  describe("replaceItem", () => {
+    it("should replace and return the item", async () => {
+      const replaceItemDto: ReplaceMediaItemDto = {
+        type: "video",
+        original_filename: "vid.mp4",
+        position: "main",
+        width: 1920,
+        height: 1080,
+        title: { en: "Vid Title", nl: "Vid Title" },
+        description: { en: "Vid Desc", nl: "Vid Desc" },
+        credits: { en: "Vid Credits", nl: "Vid Credits" },
+      };
+      mediaDbService.updateItem.mockResolvedValue(mockItem);
+
+      const result = await service.replaceItem(1, replaceItemDto);
+
+      expect(mediaDbService.updateItem).toHaveBeenCalledWith(1, replaceItemDto);
+      expect(result).toEqual(mockItem);
+    });
+  });
+
+  describe("modifyItem", () => {
+    it("should fetch the existing item, merge modifications, and update", async () => {
+      const modifyItemDto: ModifyMediaItemDto = { position: "carousel" };
+
+      const expectedMergedItem: MediaItemDto = {
+        ...mockItem,
+        ...modifyItemDto,
+        id: 1,
+      };
+
+      mediaDbService.getItemById.mockResolvedValue(mockItem);
+      mediaDbService.updateItem.mockResolvedValue(expectedMergedItem);
+
+      const result = await service.modifyItem(1, modifyItemDto);
+
+      expect(mediaDbService.getItemById).toHaveBeenCalledWith(1);
+      expect(mediaDbService.updateItem).toHaveBeenCalledWith(
+        1,
+        expectedMergedItem,
+      );
+      expect(result).toEqual(expectedMergedItem);
+    });
+  });
+
+  describe("deleteItem", () => {
+    it("should delete the item", async () => {
+      mediaDbService.deleteItem.mockResolvedValue(undefined);
+
+      await service.deleteItem(1);
+
+      expect(mediaDbService.deleteItem).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("getItemCrops", () => {
+    it("should return all crops for an item", async () => {
+      mediaDbService.getCropsByItem.mockResolvedValue([mockCrop]);
+
+      const result = await service.getItemCrops(1);
+
+      expect(mediaDbService.getCropsByItem).toHaveBeenCalledWith(1);
+      expect(result).toEqual([mockCrop]);
+    });
+  });
+
+  describe("linkCropToItem", () => {
+    it("should link a crop to an item", async () => {
+      mediaDbService.linkCropToItem.mockResolvedValue(undefined);
+
+      await service.linkCropToItem(1, 2);
+
+      expect(mediaDbService.linkCropToItem).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
+  describe("unlinkCropFromItem", () => {
+    it("should unlink a crop from an item", async () => {
+      mediaDbService.unlinkCropFromItem.mockResolvedValue(undefined);
+
+      await service.unlinkCropFromItem(1, 2);
+
+      expect(mediaDbService.unlinkCropFromItem).toHaveBeenCalledWith(1, 2);
+    });
+  });
+});

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -17,6 +17,8 @@ import request from "supertest";
 import { ApiKeyGuard } from "../src/auth/authGuard";
 import { AppLogger } from "../src/util/logger/logger.service";
 import { ScraperService } from "../src/util/scraper/scraper.service";
+import { MediaModule } from "../src/media/media.module";
+import { MediaDatabaseService } from "../src/database/db.media.service";
 
 // ==========================================
 // MOCK DATA (Raw & View Variants)
@@ -186,6 +188,86 @@ const mockPriceDbService = () => ({
   deletePrice: jest.fn().mockResolvedValue(undefined),
 });
 
+// ==========================================
+// MOCK DATA (Media)
+// ==========================================
+
+const mockMediaCrop = {
+  id: 1,
+  name: "hd_ready",
+  url: "https://example.com/crop.jpg",
+  created_at: "2026-03-28T14:00:00.000Z",
+  updated_at: "2026-03-28T14:00:00.000Z",
+};
+
+const mockMediaItem = {
+  id: 1,
+  type: "image",
+  original_filename: "test.png",
+  position: "main",
+  width: 1920,
+  height: 1080,
+  title: { en: "Test Media", nl: "Test Media" },
+  description: { en: "Desc", nl: "Beschrijving" },
+  credits: { en: "Credits", nl: "Credits" },
+  created_at: "2026-03-28T14:00:00.000Z",
+  updated_at: "2026-03-28T14:00:00.000Z",
+};
+
+const mockMediaItemView = {
+  ...mockMediaItem,
+  title: "Test Media",
+  description: "Desc",
+  credits: "Credits",
+};
+
+const mockMediaGallery = {
+  id: 1,
+  created_at: "2026-03-28T14:00:00.000Z",
+  updated_at: "2026-03-28T14:00:00.000Z",
+};
+
+const paginatedResponse = (objects) => ({
+  objects,
+  totalItems: 1,
+  page: 1,
+  limit: 10,
+});
+
+// ==========================================
+// Mock DB service factory (Media)
+// ==========================================
+
+const mockMediaDbService = () => ({
+  // Crops
+  getAllCrops: jest.fn().mockResolvedValue(paginatedResponse([mockMediaCrop])),
+  getCropById: jest.fn().mockResolvedValue(mockMediaCrop),
+  createCrop: jest.fn().mockResolvedValue(mockMediaCrop),
+  updateCrop: jest.fn().mockResolvedValue(mockMediaCrop),
+  deleteCrop: jest.fn().mockResolvedValue(undefined),
+
+  // Items
+  getAllItems: jest.fn().mockResolvedValue(paginatedResponse([mockMediaItem])),
+  getItemById: jest.fn().mockResolvedValue(mockMediaItem),
+  createItem: jest.fn().mockResolvedValue(mockMediaItem),
+  updateItem: jest.fn().mockResolvedValue(mockMediaItem),
+  deleteItem: jest.fn().mockResolvedValue(undefined),
+  getCropsByItem: jest.fn().mockResolvedValue([mockMediaCrop]),
+  linkCropToItem: jest.fn().mockResolvedValue(undefined),
+  unlinkCropFromItem: jest.fn().mockResolvedValue(undefined),
+
+  // Galleries
+  getGalleries: jest
+    .fn()
+    .mockResolvedValue(paginatedResponse([mockMediaGallery])),
+  getGalleryById: jest.fn().mockResolvedValue(mockMediaGallery),
+  createGallery: jest.fn().mockResolvedValue(mockMediaGallery),
+  deleteGallery: jest.fn().mockResolvedValue(undefined),
+  getItemsByGallery: jest.fn().mockResolvedValue([mockMediaItem]),
+  linkItemToGallery: jest.fn().mockResolvedValue(undefined),
+  unlinkItemFromGallery: jest.fn().mockResolvedValue(undefined),
+});
+
 // Helper: build app with all modules
 async function buildApp(): Promise<INestApplication> {
   const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -196,6 +278,7 @@ async function buildApp(): Promise<INestApplication> {
       TagModule,
       LocationModule,
       PriceModule,
+      MediaModule,
     ],
   })
     .overrideGuard(ApiKeyGuard)
@@ -212,6 +295,8 @@ async function buildApp(): Promise<INestApplication> {
     .useFactory({ factory: mockLocationDbService })
     .overrideProvider(PriceDatabaseService)
     .useFactory({ factory: mockPriceDbService })
+    .overrideProvider(MediaDatabaseService)
+    .useFactory({ factory: mockMediaDbService })
     .overrideProvider(AppLogger) // We override these so they don't make a fuss during testing.
     .useValue({
       log: jest.fn(),
@@ -1270,6 +1355,271 @@ describe("EventPriceController (e2e)", () => {
       return request(app.getHttpServer())
         .delete("/events/1/prices/abc")
         .expect(400);
+    });
+  });
+});
+
+// ==========================================
+// MEDIA CROP endpoints
+// ==========================================
+
+describe("MediaCropController (e2e)", () => {
+  let app: INestApplication;
+  let mediaDb: MediaDatabaseService; // Using any or MediaDatabaseService type if imported
+
+  beforeEach(async () => {
+    app = await buildApp();
+    // Adjust token if needed based on how it's exported
+    mediaDb = app.get<MediaDatabaseService>(MediaDatabaseService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe("GET /crops", () => {
+    it("should return 200 with a paginated list of crops", () => {
+      return request(app.getHttpServer())
+        .get("/crops?page=1&limit=10")
+        .expect(200)
+        .expect(paginatedResponse([mockMediaCrop]));
+    });
+  });
+
+  describe("GET /crops/:cropId", () => {
+    it("should return 200 with the correct crop", () => {
+      return request(app.getHttpServer())
+        .get("/crops/1")
+        .expect(200)
+        .expect(mockMediaCrop);
+    });
+  });
+
+  describe("POST /crops", () => {
+    it("should return 201 with the created crop", () => {
+      return request(app.getHttpServer())
+        .post("/crops")
+        .send({ item_id: 1, name: "hd_ready", url: "https://test.com/a.jpg" })
+        .expect(201)
+        .expect(mockMediaCrop);
+    });
+  });
+
+  describe("PUT /crops/:cropId", () => {
+    it("should return 200 with the replaced crop", () => {
+      return request(app.getHttpServer())
+        .put("/crops/1")
+        .send({ name: "mobile", url: "https://test.com/b.jpg" })
+        .expect(200)
+        .expect(mockMediaCrop);
+    });
+  });
+
+  describe("PATCH /crops/:cropId", () => {
+    it("should return 200 with the modified crop", () => {
+      return request(app.getHttpServer())
+        .patch("/crops/1")
+        .send({ url: "https://test.com/new.jpg" })
+        .expect(200)
+        .expect(mockMediaCrop);
+    });
+  });
+
+  describe("DELETE /crops/:cropId", () => {
+    it("should return 200 after deleting crop", () => {
+      return request(app.getHttpServer()).delete("/crops/1").expect(200);
+    });
+  });
+});
+
+// ==========================================
+// MEDIA ITEM endpoints
+// ==========================================
+
+describe("MediaItemController (e2e)", () => {
+  let app: INestApplication;
+  let mediaDb: MediaDatabaseService;
+
+  beforeEach(async () => {
+    app = await buildApp();
+    mediaDb = app.get<MediaDatabaseService>(MediaDatabaseService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe("GET /items", () => {
+    it("should return 200 with a paginated list of flattened items", () => {
+      return request(app.getHttpServer())
+        .get("/items?lang=en")
+        .expect(200)
+        .expect(paginatedResponse([mockMediaItemView]));
+    });
+  });
+
+  describe("GET /items/:itemId", () => {
+    it("should return 200 with the correct flattened item", () => {
+      return request(app.getHttpServer())
+        .get("/items/1?lang=en")
+        .expect(200)
+        .expect(mockMediaItemView);
+    });
+  });
+
+  describe("POST /items", () => {
+    it("should return 201 with the created item", () => {
+      return request(app.getHttpServer())
+        .post("/items")
+        .send({
+          type: "image",
+          original_filename: "test.png",
+          position: "main",
+          width: 1920,
+          height: 1080,
+          title: { en: "Test Media", nl: "Test Media" },
+          description: { en: "Desc", nl: "Beschrijving" },
+          credits: { en: "Credits", nl: "Credits" },
+        })
+        .expect(201)
+        .expect(mockMediaItem);
+    });
+  });
+
+  describe("PUT /items/:itemId", () => {
+    it("should return 200 with the replaced item", () => {
+      return request(app.getHttpServer())
+        .put("/items/1")
+        .send({
+          type: "image",
+          original_filename: "test.png",
+          position: "main",
+          width: 1920,
+          height: 1080,
+          title: { en: "Test Media", nl: "Test Media" },
+          description: { en: "Desc", nl: "Beschrijving" },
+          credits: { en: "Credits", nl: "Credits" },
+        })
+        .expect(200)
+        .expect(mockMediaItem);
+    });
+  });
+
+  describe("PATCH /items/:itemId", () => {
+    it("should return 200 with the modified item", () => {
+      return request(app.getHttpServer())
+        .patch("/items/1")
+        .send({ position: "carousel" })
+        .expect(200)
+        .expect(mockMediaItem);
+    });
+  });
+
+  describe("DELETE /items/:itemId", () => {
+    it("should return 200 after deleting item", () => {
+      return request(app.getHttpServer()).delete("/items/1").expect(200);
+    });
+  });
+
+  // Relationships: Item <-> Crops
+  describe("GET /items/:itemId/crops", () => {
+    it("should return 200 with the crops of the item", () => {
+      return request(app.getHttpServer())
+        .get("/items/1/crops")
+        .expect(200)
+        .expect([mockMediaCrop]);
+    });
+  });
+
+  describe("PUT /items/:itemId/crops/:cropId", () => {
+    it("should return 200 after successfully linking crop", () => {
+      return request(app.getHttpServer()).put("/items/1/crops/2").expect(200);
+    });
+  });
+
+  describe("DELETE /items/:itemId/crops/:cropId", () => {
+    it("should return 200 after unlinking crop", () => {
+      return request(app.getHttpServer())
+        .delete("/items/1/crops/2")
+        .expect(200);
+    });
+  });
+});
+
+// ==========================================
+// MEDIA GALLERY endpoints
+// ==========================================
+
+describe("MediaGalleryController (e2e)", () => {
+  let app: INestApplication;
+  let mediaDb: MediaDatabaseService;
+
+  beforeEach(async () => {
+    app = await buildApp();
+    mediaDb = app.get<MediaDatabaseService>(MediaDatabaseService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe("GET /galleries", () => {
+    it("should return 200 with a paginated list of galleries", () => {
+      return request(app.getHttpServer())
+        .get("/galleries?page=1&limit=10")
+        .expect(200)
+        .expect(paginatedResponse([mockMediaGallery]));
+    });
+  });
+
+  describe("GET /galleries/:galleryId", () => {
+    it("should return 200 with the correct gallery", () => {
+      return request(app.getHttpServer())
+        .get("/galleries/1")
+        .expect(200)
+        .expect(mockMediaGallery);
+    });
+  });
+
+  describe("POST /galleries", () => {
+    it("should return 201 with the created gallery", () => {
+      return request(app.getHttpServer())
+        .post("/galleries")
+        .send({}) // Based on schema, fields are mostly auto-generated
+        .expect(201)
+        .expect(mockMediaGallery);
+    });
+  });
+
+  describe("DELETE /galleries/:galleryId", () => {
+    it("should return 200 after deleting gallery", () => {
+      return request(app.getHttpServer()).delete("/galleries/1").expect(200);
+    });
+  });
+
+  // Relationships: Gallery <-> Items
+  describe("GET /galleries/:galleryId/items", () => {
+    it("should return 200 with items of the gallery", () => {
+      return request(app.getHttpServer())
+        .get("/galleries/1/items")
+        .expect(200)
+        .expect([mockMediaItem]);
+    });
+  });
+
+  describe("PUT /galleries/:galleryId/items/:itemId", () => {
+    it("should return 200 after linking item to gallery", () => {
+      return request(app.getHttpServer())
+        .put("/galleries/1/items/2")
+        .expect(200);
+    });
+  });
+
+  describe("DELETE /galleries/:galleryId/items/:itemId", () => {
+    it("should return 200 after unlinking item from gallery", () => {
+      return request(app.getHttpServer())
+        .delete("/galleries/1/items/2")
+        .expect(200);
     });
   });
 });


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] This PR implements additional tests for the media endpoints (service, controller, e2e and auth)

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 🔍 HOW TO TEST

run `npm run test`

## ⚠️ REMAINING ISSUES

* For the `production` and `blog` specific tests I've moved to #263 #264 because these will still change when #219 are implemented.

## ✅ CLOSED ISSUES
- Closes #258 
