### PR TITLE
Add superAdmin field to PublicAccount

### DIFF
--- a/backend/src/database/db.account.service.ts
+++ b/backend/src/database/db.account.service.ts
@@ -110,12 +110,14 @@ export class AccountDatabaseService {
     const apiKey = await this.getApiKeyFromAccount({
       id: dbAccount.id,
       username: dbAccount.username,
+      superAdmin: dbAccount.superAdmin,
     });
 
     // 4. Return safe account info + apiKey
     const publicAccount: PublicAccountDto = {
       id: dbAccount.id,
       username: dbAccount.username,
+      superAdmin: dbAccount.superAdmin,
     };
 
     return { account: publicAccount, apiKey };

--- a/common/src/objects/accounts.ts
+++ b/common/src/objects/accounts.ts
@@ -18,7 +18,6 @@ export const UpdateAccountSchema = AccountSchema.partial();
 // Public Account object.
 export const PublicAccountSchema = AccountSchema.omit({
   password: true,
-  superAdmin: true,
 }); // don't leak these. (note: still contains your id so you can still get your api key through that.)
 
 // Type exports.


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR fixes some existing bugs
* Adds the `superAdmin` field to the PublicAccount object so the frontend can use it to display accounts properly.

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

None needed to be altered.

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code
- [x] external documentation (README, etc.) has been changed

No changes.

## 🔍 HOW TO TEST

Go to Swagger and ask for the Account endpoints.

## ✅ CLOSED ISSUES

No issue linked to this.
