### PR TITLE
Fix Print Item Filter + Blog Filter

### DIFF
--- a/backend/src/database/db.blog.service.ts
+++ b/backend/src/database/db.blog.service.ts
@@ -75,7 +75,7 @@ export class BlogDatabaseService {
     // Title filter
     // NOTE: This is case-insensitive and looks in all languages + matches on parts.
     if (blogFilters.title) {
-      const titleParam = param(blogFilters.title);
+      const titleParam = param(`%${blogFilters.title}%`);
       const titelClauses = SUPPORTED_LANGUAGES.map(
         (lang) => `titel->>'${lang}' ILIKE ${titleParam}`,
       );

--- a/backend/src/database/db.blog.service.ts
+++ b/backend/src/database/db.blog.service.ts
@@ -84,12 +84,12 @@ export class BlogDatabaseService {
 
     // Filter blogs that were created before.
     if (blogFilters.before) {
-      conditions.push(`created_at < ${param(blogFilters.before)}::timestamp`);
+      conditions.push(`created_at::date <= ${param(blogFilters.before)}::date`);
     }
 
     // Filter blogs that were created after.
     if (blogFilters.after) {
-      conditions.push(`created_at > ${param(blogFilters.after)}::timestamp`);
+      conditions.push(`created_at::date >= ${param(blogFilters.after)}::date`);
     }
 
     const whereClause = conditions.length

--- a/backend/src/database/db.print_item.service.ts
+++ b/backend/src/database/db.print_item.service.ts
@@ -6,7 +6,7 @@ import {
   ModifyPrintItemDto,
   PaginationFilterDto,
   ReplacePrintItemDto,
-  PrintType,
+  FilterPrintItemDto,
 } from "../dto/dto";
 import { PaginatedResponse } from "@repo/common/src/objects/pagination";
 import {
@@ -14,7 +14,7 @@ import {
   generateReturningClause,
   generateUpdateClause,
 } from "./db-utils";
-import { PrintItemSchema } from "@repo/common";
+import { PrintItemSchema, SUPPORTED_LANGUAGES } from "@repo/common";
 import { ResourceNotFoundException } from "../common/exceptions";
 
 @Injectable()
@@ -57,28 +57,57 @@ export class PrintItemDatabaseService {
    */
   async getAllPrintItems(
     paginationFilters: PaginationFilterDto,
-    print_type?: PrintType,
+    printItemFilters: FilterPrintItemDto,
   ): Promise<PaginatedResponse<PrintItemDto>> {
     const returningClause = generateReturningClause(PrintItemSchema);
-    const offset = paginationFilters.page * paginationFilters.limit;
-    let query = `SELECT ${returningClause} FROM print_items`;
-    let countQuery = `SELECT COUNT(*) as count FROM print_items`;
-    const values: any[] = [];
-    const countValues: any[] = [];
-    if (print_type) {
-      query += ` WHERE print_type = $1`;
-      countQuery += ` WHERE print_type = $1`;
-      values.push(print_type);
-      countValues.push(print_type);
-    }
-    const limitIndex = values.length + 1;
-    const offsetIndex = values.length + 2;
 
-    query += ` LIMIT $${limitIndex} OFFSET $${offsetIndex};`;
-    values.push(paginationFilters.limit, offset);
+    const conditions: string[] = [];
+    const values: any[] = [];
+    const param = (val: any) => {
+      values.push(val);
+      return `$${values.length}`;
+    };
+
+    // Title filter
+    // NOTE: This is case-insensitive and looks in all languages + matches on parts.
+    if (printItemFilters.title) {
+      const titleParam = param(`%${printItemFilters.title}%`);
+      const titelClauses = SUPPORTED_LANGUAGES.map(
+        (lang) => `titel->>'${lang}' ILIKE ${titleParam}`,
+      );
+      conditions.push(`(${titelClauses.join(" OR ")})`);
+    }
+
+    // Filter for prints of a certain type
+    if (printItemFilters.type) {
+      conditions.push(`print_type = ${param(printItemFilters.type)}`);
+    }
+
+    const whereClause = conditions.length
+      ? `WHERE ${conditions.join(" AND ")}`
+      : "";
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const filterValues = [...values];
+    const countQuery = `
+      SELECT COUNT(*) as count FROM print_items
+      ${whereClause};
+    `;
+
+    // pagination
+    const offset = paginationFilters.page * paginationFilters.limit;
+    const paginationClause = `LIMIT ${param(paginationFilters.limit)} OFFSET ${param(offset)}`;
+
+    const query = `
+      SELECT ${returningClause}
+      FROM print_items
+      ${whereClause}
+      ORDER BY created_at ${paginationFilters.descending ? "DESC" : "ASC"}
+      ${paginationClause};
+    `;
     const [objects, countResult] = await Promise.all([
       this.db.query<PrintItemDto>(query, values),
-      this.db.query<{ count: string }>(countQuery, countValues),
+      this.db.query<{ count: string }>(countQuery, filterValues),
     ]);
 
     return {

--- a/backend/src/database/db.print_item.service.ts
+++ b/backend/src/database/db.print_item.service.ts
@@ -52,7 +52,7 @@ export class PrintItemDatabaseService {
   /**
    * Get all print items paginated.
    * @param paginationFilters The Filters regarding ordering and pagination.
-   * @param print_type Optional filter by print type.
+   * @param printItemFilters The filters for the prints.
    * @returns The PrintItems.
    */
   async getAllPrintItems(

--- a/backend/src/dto/dto.ts
+++ b/backend/src/dto/dto.ts
@@ -55,6 +55,7 @@ import {
   VerifyApiKeySchema,
   FilterBlogSchema,
   AccountSchema,
+  FilterPrintItemSchema,
 } from "@repo/common";
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { createZodDto } from "nestjs-zod";
@@ -142,12 +143,12 @@ export class ModifyMediaCropDto extends createZodDto(ModifyMediaCropSchema) {}
 export class ReplaceMediaCropDto extends createZodDto(ReplaceMediaCropSchema) {}
 
 // Prints
-export { type PrintType, PrintTypeSchema, PrintTypeValues } from "@repo/common";
 export class PrintItemDto extends createZodDto(PrintItemSchema) {}
 export class PrintItemViewDto extends createZodDto(PrintItemViewSchema) {}
 export class CreatePrintItemDto extends createZodDto(CreatePrintItemSchema) {}
 export class ModifyPrintItemDto extends createZodDto(ModifyPrintItemSchema) {}
 export class ReplacePrintItemDto extends createZodDto(ReplacePrintItemSchema) {}
+export class FilterPrintItemDto extends createZodDto(FilterPrintItemSchema) {}
 
 // CSV Upload DTO
 export class ParserUploadCsvBodyDto {

--- a/backend/src/print/print_item.controller.spec.ts
+++ b/backend/src/print/print_item.controller.spec.ts
@@ -12,6 +12,7 @@ import {
   ReplacePrintItemDto,
   PaginationFilterDto,
   LanguageQueryDto,
+  FilterPrintItemDto,
 } from "../dto/dto";
 
 describe("PrintItemController", () => {
@@ -107,11 +108,12 @@ describe("PrintItemController", () => {
       const result = await controller.getPrintItems(
         paginationFilter,
         langQuery,
+        {},
       );
 
       expect(printItemService.getPrintItems).toHaveBeenCalledWith(
         paginationFilter,
-        undefined,
+        {},
       );
       expect(languageService.flattenByLanguage).toHaveBeenCalledWith(
         paginatedItems,
@@ -120,14 +122,17 @@ describe("PrintItemController", () => {
       expect(result).toEqual(expectedFlattened);
     });
 
-    it("should pass the type parameter to the service when provided", async () => {
+    it("should pass the filters parameter to the service when provided", async () => {
       const paginationFilter: PaginationFilterDto = {
         page: 1,
         limit: 10,
         descending: true,
       };
       const langQuery: LanguageQueryDto = { lang: "en" };
-      const testType = "brochure";
+      const filters: FilterPrintItemDto = {
+        type: "affiche",
+        title: "brugge",
+      };
 
       const paginatedItems: PaginatedResponse<PrintItemDto> = {
         objects: [],
@@ -139,11 +144,11 @@ describe("PrintItemController", () => {
       printItemService.getPrintItems.mockResolvedValue(paginatedItems);
       languageService.flattenByLanguage.mockReturnValue(paginatedItems as any);
 
-      await controller.getPrintItems(paginationFilter, langQuery, testType);
+      await controller.getPrintItems(paginationFilter, langQuery, filters);
 
       expect(printItemService.getPrintItems).toHaveBeenCalledWith(
         paginationFilter,
-        testType,
+        filters,
       );
     });
   });

--- a/backend/src/print/print_item.controller.ts
+++ b/backend/src/print/print_item.controller.ts
@@ -63,6 +63,7 @@ export class PrintItemController {
    * Responds to a GET to "/prints".
    * @param paginationFilter The Filters for pagination and ordering.
    * @param lang The Language Query.
+   * @param printItemFilters The filters for the prints.
    * @returns A paginated list of print items.
    */
   @ApiOperation({ summary: "Fetch a paginated list of print items." })

--- a/backend/src/print/print_item.controller.ts
+++ b/backend/src/print/print_item.controller.ts
@@ -20,6 +20,7 @@ import {
   ModifyPrintItemSchema,
   PaginationFilterSchema,
   ReplacePrintItemSchema,
+  FilterPrintItemSchema,
 } from "@repo/common";
 import {
   PrintItemDto,
@@ -29,9 +30,7 @@ import {
   ReplacePrintItemDto,
   PaginationFilterDto,
   PrintItemViewDto,
-  PrintType,
-  PrintTypeSchema,
-  PrintTypeValues,
+  FilterPrintItemDto,
 } from "../dto/dto";
 import { LanguageService } from "../util/language/language.service";
 import { ZodValidationPipe } from "nestjs-zod";
@@ -42,7 +41,6 @@ import {
   ApiOperation,
   ApiSecurity,
   ApiTags,
-  ApiQuery,
 } from "@nestjs/swagger";
 import {
   ApiOkAnyOf,
@@ -68,27 +66,21 @@ export class PrintItemController {
    * @returns A paginated list of print items.
    */
   @ApiOperation({ summary: "Fetch a paginated list of print items." })
-  @ApiQuery({
-    name: "type",
-    enum: PrintTypeValues,
-    required: false,
-    description: "Filter by print type.",
-  })
   @ApiOkPaginatedResponseAnyOf(PrintItemDto, PrintItemViewDto)
   @Get()
   async getPrintItems(
     @Query(new ZodValidationPipe(PaginationFilterSchema))
     paginationFilter: PaginationFilterDto,
     @Query(new ZodValidationPipe(LanguageQuerySchema)) lang: LanguageQueryDto,
-    @Query("type", new ZodValidationPipe(PrintTypeSchema.optional()))
-    print_type?: string,
+    @Query(new ZodValidationPipe(FilterPrintItemSchema))
+    printItemFilters: FilterPrintItemDto,
   ): Promise<PaginatedResponse<PrintItemDto | PrintItemViewDto>> {
     return this.ls.flattenByLanguage<
       PaginatedResponse<PrintItemDto | PrintItemViewDto>
     >(
       await this.printItemService.getPrintItems(
         paginationFilter,
-        print_type as PrintType,
+        printItemFilters,
       ),
       lang.lang,
     );

--- a/backend/src/print/print_item.service.spec.ts
+++ b/backend/src/print/print_item.service.spec.ts
@@ -8,6 +8,7 @@ import {
   ModifyPrintItemDto,
   PaginationFilterDto,
   ReplacePrintItemDto,
+  FilterPrintItemDto,
 } from "../dto/dto";
 
 describe("PrintItemService", () => {
@@ -67,24 +68,25 @@ describe("PrintItemService", () => {
         limit: 10,
       };
 
+      const filters = {};
+
       printDbService.getAllPrintItems.mockResolvedValue(expectedResponse);
 
-      const result = await service.getPrintItems(paginationFilters);
+      const result = await service.getPrintItems(paginationFilters, filters);
 
       expect(printDbService.getAllPrintItems).toHaveBeenCalledWith(
         paginationFilters,
-        undefined,
+        filters,
       );
       expect(result).toEqual(expectedResponse);
     });
 
-    it("should pass the type parameter to the db service", async () => {
+    it("should pass the filters parameter to the db service", async () => {
       const paginationFilters: PaginationFilterDto = {
         page: 1,
         limit: 10,
         descending: true,
       };
-      const testType = "drukwerk";
 
       const expectedResponse: PaginatedResponse<PrintItemDto> = {
         objects: [],
@@ -93,13 +95,17 @@ describe("PrintItemService", () => {
         limit: 10,
       };
 
+      const filters: FilterPrintItemDto = {
+        type: "drukwerk",
+      };
+
       printDbService.getAllPrintItems.mockResolvedValue(expectedResponse);
 
-      await service.getPrintItems(paginationFilters, testType);
+      await service.getPrintItems(paginationFilters, filters);
 
       expect(printDbService.getAllPrintItems).toHaveBeenCalledWith(
         paginationFilters,
-        testType,
+        filters,
       );
     });
   });

--- a/backend/src/print/print_item.service.ts
+++ b/backend/src/print/print_item.service.ts
@@ -26,6 +26,7 @@ export class PrintItemService {
   /**
    * Fetches all PrintItem objects from the database.
    * @param paginationFilter Filters for pagination and ordering.
+   * @param printItemFilters The filters for the prints.
    * @returns All PrintItems.
    */
   async getPrintItems(

--- a/backend/src/print/print_item.service.ts
+++ b/backend/src/print/print_item.service.ts
@@ -7,7 +7,7 @@ import {
   PrintItemDto,
   ReplacePrintItemDto,
 } from "../dto/dto";
-import type { PrintType } from "../dto/dto";
+import type { FilterPrintItemDto } from "../dto/dto";
 import { PaginatedResponse } from "@repo/common";
 
 @Injectable()
@@ -30,11 +30,11 @@ export class PrintItemService {
    */
   async getPrintItems(
     paginationFilter: PaginationFilterDto,
-    print_type?: PrintType,
+    printItemFilters: FilterPrintItemDto,
   ): Promise<PaginatedResponse<PrintItemDto>> {
     return await this.printItemDbService.getAllPrintItems(
       paginationFilter,
-      print_type,
+      printItemFilters,
     );
   }
 

--- a/common/src/objects/print_item.ts
+++ b/common/src/objects/print_item.ts
@@ -34,6 +34,7 @@ export const PrintItemViewSchema = PrintItemSchema.extend({
   description: z.string(),
 });
 
+// Omits read-only fields.
 const MutablePrintItemSchema = PrintItemSchema.omit({
   id: true,
   created_at: true,
@@ -47,8 +48,16 @@ export const CreatePrintItemSchema = MutablePrintItemSchema.extend({
 export const ModifyPrintItemSchema = MutablePrintItemSchema.partial();
 export const ReplacePrintItemSchema = MutablePrintItemSchema;
 
+// Filtering.
+export const FilterPrintItemSchema = z.object({
+  title: z.string().optional(),
+  type: PrintTypeSchema.optional(),
+});
+
+// Type exports.
 export type PrintItem = z.infer<typeof PrintItemSchema>;
 export type PrintItemView = z.infer<typeof PrintItemViewSchema>;
 export type CreatePrintItem = z.infer<typeof CreatePrintItemSchema>;
 export type ModifyPrintItem = z.infer<typeof ModifyPrintItemSchema>;
 export type ReplacePrintItem = z.infer<typeof ReplacePrintItemSchema>;
+export type FilterPrintItem = z.infer<typeof FilterPrintItemSchema>;

--- a/frontend/app/components/DefaultCalendar.vue
+++ b/frontend/app/components/DefaultCalendar.vue
@@ -12,7 +12,6 @@ import {
   localIso,
   localTodayIso,
   buildWeekdayLabels,
-  addDays,
 } from "~/utils/formatters";
 import type { CalMode } from "./calendar/CalendarInputs.vue";
 import type { MonthData } from "./calendar/CalendarMonths.vue";
@@ -119,24 +118,24 @@ const filter = computed<DateFilter>(() => {
   switch (mode.value) {
     case "single":
       return selected.value
-        ? { after: selected.value, before: addDays(selected.value, 1) }
+        ? { after: selected.value, before: selected.value }
         : {};
 
     case "range": {
       if (!anchor.value || !selected.value) return {};
       const [a, b] = sorted(anchor.value, selected.value);
-      return { after: a, before: addDays(b, 1) };
+      return { after: a, before: b };
     }
 
     case "after-selected":
       return anchor.value
-        ? { after: anchor.value, before: addDays(todayIso.value, 1) }
+        ? { after: anchor.value, before: todayIso.value }
         : {};
 
     case "before-selected":
       if (!props.oldestDate) return {};
       return selected.value
-        ? { after: props.oldestDate, before: addDays(selected.value, 1) }
+        ? { after: props.oldestDate, before: selected.value }
         : { after: props.oldestDate };
   }
 });

--- a/frontend/app/composables/media/usePrintApi.ts
+++ b/frontend/app/composables/media/usePrintApi.ts
@@ -1,5 +1,6 @@
 import type {
   CreatePrintItem,
+  FilterPrintItem,
   Language,
   LanguageQuery,
   ModifyPrintItem,
@@ -7,14 +8,13 @@ import type {
   PaginationFilter,
   PrintItem,
   PrintItemView,
-  PrintType,
   ReplacePrintItem,
 } from "@repo/common";
 
 interface PrintItemListOptions {
   paginationFilters?: PaginationFilter;
   languageFilters?: LanguageQuery;
-  type?: PrintType;
+  printItemFilters?: FilterPrintItem;
 }
 
 /**
@@ -29,12 +29,12 @@ export function usePrintApi() {
   const getAll = ({
     paginationFilters,
     languageFilters,
-    type,
+    printItemFilters,
   }: PrintItemListOptions = {}) => {
     const params = {
       ...paginationFilters,
       ...languageFilters,
-      type,
+      ...printItemFilters,
     };
 
     const cleanParams = Object.fromEntries(

--- a/frontend/app/utils/formatters.ts
+++ b/frontend/app/utils/formatters.ts
@@ -20,12 +20,6 @@ export function isoYear(iso: string): number {
   return parseInt(iso.split("-")[0] ?? "0", 10);
 }
 
-/** Add n days to an ISO date string, returns a new ISO date string. */
-export function addDays(iso: string, n: number): string {
-  const [y, m, d] = iso.split("-").map(Number) as [number, number, number];
-  return localIso(new Date(y, m - 1, d + n));
-}
-
 /**
  * Validate a YYYY-MM-DD string: checks calendar validity and rejects future dates.
  * Returns the ISO string on success, null on failure.

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -53,6 +53,7 @@ export default defineNuxtConfig({
         '@vue/devtools-kit',
         'lucide-vue-next',
         'zod',
+        'pdfjs-dist',
       ]
     }
   }

--- a/frontend/tests/composables/usePrintApi.spec.ts
+++ b/frontend/tests/composables/usePrintApi.spec.ts
@@ -35,7 +35,7 @@ describe("usePrintApi", () => {
     void getAll({
       paginationFilters: { page: 1, limit: 10, descending: true },
       languageFilters: { lang: "en" },
-      type: "affiche",
+      printItemFilters: { type: "affiche" },
     });
     const url = mockGet.mock.calls[0][0] as string;
     expect(url).toContain("page=1");


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR fixes some existing bugs

### Changelog

* Print items now have filters for their `getAll` endpoint. You can ask for a `title` filter that will try to match with any language partially and the `type` is now also in the filter object.

* Fixed a bug where the `Blog` filter for `title` wouldn't match with anything partially.

* Fixed a bug where the `Blog` date filters weren't inclusive. They now are and the frontend has been adjusted according to the issue description. 

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

The tests have been altered for the new values.

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code
- [x] external documentation (README, etc.) has been changed

No changes here.

## ✅ CLOSED ISSUES

- Closes #346 
- Closes #387