### PR TITLE
Fix Verbose Console Prints + More

### DIFF
--- a/backend/src/auth/auth.spec.ts
+++ b/backend/src/auth/auth.spec.ts
@@ -48,7 +48,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/events")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -57,7 +57,7 @@ describe("AuthGuards tests", () => {
         .get("/events/1")
         .send({})
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -85,7 +85,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/events/1/location")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
   });
@@ -95,7 +95,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/events/1/location")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -117,7 +117,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/events/1/prices")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -139,7 +139,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/productions")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -148,7 +148,7 @@ describe("AuthGuards tests", () => {
         .get("/productions/1")
         .send({})
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -184,7 +184,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/productions/1/blogs")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -207,7 +207,7 @@ describe("AuthGuards tests", () => {
       const response = await request(app.getHttpServer() as Server).get(
         "/productions/1/tags",
       );
-      expect([200, 410]).toContain(response.status);
+      expect([200, 404]).toContain(response.status);
     });
 
     it("PUT /productions/:id/tags/:id should fail without API key", async () => {
@@ -229,7 +229,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/tags")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -245,7 +245,7 @@ describe("AuthGuards tests", () => {
         .get("/tags/1")
         .send({})
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -267,7 +267,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/blogs?descending=true")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -283,7 +283,7 @@ describe("AuthGuards tests", () => {
         .get("/blogs/1")
         .send({})
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -311,7 +311,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/locations")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -319,7 +319,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/locations/1")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -347,7 +347,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/prices")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -355,7 +355,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/prices/2")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -416,7 +416,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/crops")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -424,7 +424,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/crops/1")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -461,7 +461,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/items")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -469,7 +469,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/items/1")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -505,7 +505,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/items/1/crops")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -527,7 +527,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/galleries")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -535,7 +535,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/galleries/1")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 
@@ -557,7 +557,7 @@ describe("AuthGuards tests", () => {
       await request(app.getHttpServer() as Server)
         .get("/media/galleries/1/items")
         .expect((res) => {
-          expect([200, 410]).toContain(res.status);
+          expect([200, 404]).toContain(res.status);
         });
     });
 

--- a/backend/src/production/controllers/production.controller.spec.ts
+++ b/backend/src/production/controllers/production.controller.spec.ts
@@ -176,7 +176,7 @@ describe("ProductionController", () => {
       expect(result).toEqual(mockProductionView);
     });
 
-    it("should throw a ResourceNotFoundException (410) if the production does not exist", async () => {
+    it("should throw a ResourceNotFoundException (404) if the production does not exist", async () => {
       jest
         .spyOn(service, "getProductionById")
         .mockRejectedValue(new ResourceNotFoundException(ProductionDto, 999));
@@ -193,7 +193,7 @@ describe("ProductionController", () => {
       expect(result).toEqual(mockProduction);
     });
 
-    it("should throw a ResourceNotFoundException (410) if trying to replace a non-existent production", async () => {
+    it("should throw a ResourceNotFoundException (404) if trying to replace a non-existent production", async () => {
       jest
         .spyOn(service, "replaceProduction")
         .mockRejectedValue(new ResourceNotFoundException(ProductionDto, 999));
@@ -222,7 +222,7 @@ describe("ProductionController", () => {
       expect(result).toEqual(patchedProduction);
     });
 
-    it("should throw a ResourceNotFoundException (410) if trying to modify a non-existent production", async () => {
+    it("should throw a ResourceNotFoundException (404) if trying to modify a non-existent production", async () => {
       const patchData: ModifyProductionDto = {
         titel: { en: "A New titel", nl: "Nieuwe titel" },
       };

--- a/common/src/objects/productions.ts
+++ b/common/src/objects/productions.ts
@@ -45,14 +45,16 @@ export const ReplaceProductionSchema = MutableProductionSchema;
 // Filtering.
 export const FilterProductionSchema = z.object({
   titelOrArtist: z.string().optional(),
-  tag_ids: z
-    .union([z.coerce.number(), z.array(z.coerce.number())])
-    .optional()
-    .transform((val) => {
-      if (val === undefined) return undefined;
-      if (Array.isArray(val)) return val;
-      return [val];
-    }),
+  tag_ids: z.preprocess((val) => {
+    // 1. Handle missing, null, or empty string -> undefined
+    if (val === undefined || val === null || val === "") return undefined;
+
+    // 2. Normalize single value to array
+    if (!Array.isArray(val)) return [Number(val)];
+
+    // 3. Ensure array elements are numbers
+    return val.map(Number);
+  }, z.array(z.number()).optional()),
   hall: z.string().optional(),
   before: z.iso.date().optional(),
   after: z.iso.date().optional(),

--- a/frontend/app/components/home/Highlights.vue
+++ b/frontend/app/components/home/Highlights.vue
@@ -27,6 +27,7 @@ onMounted(async () => {
   try {
     const resp = await getAll({
       paginationFilters: { page: 0, limit: 6, descending: true },
+      productionFilters: { before: new Date().toISOString().split("T")[0] },
       languageFilters: { lang: locale.value },
     });
     if (resp.data) {

--- a/frontend/app/composables/blogs/useBlogApi.ts
+++ b/frontend/app/composables/blogs/useBlogApi.ts
@@ -15,6 +15,7 @@ import type {
 import { API_ROUTES } from "~/utils/apiRoutes";
 import {
   fetchFullGallery,
+  onGalleryFetchError,
   type DefaultGallery,
   type GalleryWithItems,
   type ItemViewWithCrops,
@@ -108,6 +109,7 @@ export function useBlogApi() {
     try {
       const response = await get<DefaultGallery>(
         `${API_ROUTES.blogs.media(blogId)}?type=default`,
+        { onError: onGalleryFetchError },
       );
 
       const gallery = response.data;
@@ -128,6 +130,7 @@ export function useBlogApi() {
     try {
       const response = await get<PrintGallery>(
         `${API_ROUTES.blogs.media(blogId)}?type=prints`,
+        { onError: onGalleryFetchError },
       );
 
       const gallery = response.data;

--- a/frontend/app/composables/useProductionApi.ts
+++ b/frontend/app/composables/useProductionApi.ts
@@ -24,7 +24,7 @@ import type {
   ItemWithCrops,
   PrintGallery,
 } from "~/utils/galleryFetcher";
-import { fetchFullGallery } from "~/utils/galleryFetcher";
+import { fetchFullGallery, onGalleryFetchError } from "~/utils/galleryFetcher";
 
 interface ProductionListOptions {
   productionFilters?: FilterProduction;
@@ -167,6 +167,7 @@ export function useProductionApi() {
     try {
       const response = await get<DefaultGallery>(
         `${API_ROUTES.productions.media(productionId)}?type=default`,
+        { onError: onGalleryFetchError },
       );
 
       const gallery = response.data;
@@ -187,6 +188,7 @@ export function useProductionApi() {
     try {
       const response = await get<PrintGallery>(
         `${API_ROUTES.productions.media(productionId)}?type=prints`,
+        { onError: onGalleryFetchError },
       );
 
       const gallery = response.data;

--- a/frontend/app/utils/galleryFetcher.ts
+++ b/frontend/app/utils/galleryFetcher.ts
@@ -11,6 +11,17 @@ import type {
 import { useGalleryApi } from "~/composables/media/useGalleryApi";
 import { useItemApi } from "~/composables/media/useItemApi";
 
+/**
+ * Replaces the standard Media fetch onError.
+ * We don't have to see 404 because they are handled in code.
+ */
+export function onGalleryFetchError(status: number, message: string) {
+  if (status === 404) return;
+
+  // Print the error to the console if something more severe.
+  console.error(message);
+}
+
 export interface PrintGallery extends MediaGallery {
   type: "prints";
 }

--- a/frontend/tests/composables/useBlogApi.spec.ts
+++ b/frontend/tests/composables/useBlogApi.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useBlogApi } from "../../app/composables/blogs/useBlogApi";
+import { onGalleryFetchError } from "../../app/utils/galleryFetcher";
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
@@ -100,13 +101,17 @@ describe("useBlogApi", () => {
     it("getMediaGallery calls GET /blogs/:id/media?type=default", () => {
       const { getMediaGallery } = useBlogApi();
       void getMediaGallery(1);
-      expect(mockGet).toHaveBeenCalledWith("/blogs/1/media?type=default");
+      expect(mockGet).toHaveBeenCalledWith("/blogs/1/media?type=default", {
+        onError: onGalleryFetchError,
+      });
     });
 
     it("getPrintsGallery calls GET /blogs/:id/media?type=prints", () => {
       const { getPrintsGallery } = useBlogApi();
       void getPrintsGallery(1);
-      expect(mockGet).toHaveBeenCalledWith("/blogs/1/media?type=prints");
+      expect(mockGet).toHaveBeenCalledWith("/blogs/1/media?type=prints", {
+        onError: onGalleryFetchError,
+      });
     });
 
     it("linkMedia calls PUT /blogs/:id/media/:galleryId", () => {

--- a/frontend/tests/composables/useProductionApi.spec.ts
+++ b/frontend/tests/composables/useProductionApi.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useProductionApi } from "../../app/composables/useProductionApi";
+import { onGalleryFetchError } from "../../app/utils/galleryFetcher";
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
@@ -159,13 +160,20 @@ describe("useProductionApi", () => {
     it("getMediaGallery calls GET /productions/:id/media?type=default", () => {
       const { getMediaGallery } = useProductionApi();
       void getMediaGallery(1);
-      expect(mockGet).toHaveBeenCalledWith("/productions/1/media?type=default");
+      expect(mockGet).toHaveBeenCalledWith(
+        "/productions/1/media?type=default",
+        {
+          onError: onGalleryFetchError,
+        },
+      );
     });
 
     it("getPrintsGallery calls GET /productions/:id/media?type=prints", () => {
       const { getPrintsGallery } = useProductionApi();
       void getPrintsGallery(1);
-      expect(mockGet).toHaveBeenCalledWith("/productions/1/media?type=prints");
+      expect(mockGet).toHaveBeenCalledWith("/productions/1/media?type=prints", {
+        onError: onGalleryFetchError,
+      });
     });
 
     it("linkMedia calls PUT /productions/:id/media/:galleryId", () => {


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR fixes some existing bugs

### Changelog

* 404 Warnings were being printed out to the console when they aren't critical. This is now suppressed with a new onError function for those requests.
* The `tag_ids` filter for Productions was for some reason not optional. Is now fixed!
* The `Highlights` on the home screen were not filtering away the future productions. This now shows the same view as the productions page.

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION

Inline docs are there.

## 🔍 HOW TO TEST

Go to the site and open F12. Look at the in browser console and browse to a page that has media but no galleries.

To see the Highlights thing just go to the home page and see if the dates are correct.

## ✅ CLOSED ISSUES
- Closes #400 
