### PR TITLE
add multiple super admin support

### DIFF
--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -3,6 +3,7 @@ import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import {
   CreateAccountDto,
+  LoginDto,
   PaginationFilterDto,
   UpdateAccountDto,
 } from "../dto/dto";
@@ -23,6 +24,7 @@ describe("AuthController", () => {
   const filter: PaginationFilterDto = {
     limit: 10,
     page: 1,
+    descending: true,
   };
 
   beforeEach(async () => {
@@ -52,7 +54,7 @@ describe("AuthController", () => {
 
   describe("loginAccount", () => {
     it("should log in an account and return public account and api key", async () => {
-      const dto: CreateAccountDto = {
+      const dto: LoginDto = {
         username: "testuser",
         password: "password123",
       };
@@ -88,6 +90,7 @@ describe("AuthController", () => {
       const dto: CreateAccountDto = {
         username: "testuser",
         password: "password123",
+        superAdmin: false,
       };
       const expectedResult = { id: 1, username: "testuser", superAdmin: false };
       mockAuthService.createAccount.mockResolvedValue(expectedResult);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -15,6 +15,7 @@ import { AuthService } from "./auth.service";
 import {
   ApiKeyDto,
   CreateAccountDto,
+  LoginDto,
   PaginationFilterDto,
   PublicAccountDto,
   UpdateAccountDto,
@@ -30,6 +31,7 @@ import { SuperApiKeyGuard } from "./authGuard";
 import { ZodValidationPipe } from "nestjs-zod";
 import {
   CreateAccountSchema,
+  LoginSchema,
   PaginatedResponse,
   PaginationFilterSchema,
   UpdateAccountSchema,
@@ -47,10 +49,10 @@ export class AuthController {
    * @returns The Account and their ApiKey.
    */
   @ApiOperation({ summary: "Logs into an existing account." })
-  @UsePipes(new ZodValidationPipe(CreateAccountSchema))
+  @UsePipes(new ZodValidationPipe(LoginSchema))
   @Post("login")
   async loginAccount(
-    @Body() account: CreateAccountDto,
+    @Body() account: LoginDto,
   ): Promise<{ account: PublicAccountDto; apiKey: ApiKeyDto | null }> {
     return await this.authService.loginAccount(account);
   }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -15,6 +15,7 @@ import { AuthService } from "./auth.service";
 import {
   ApiKeyDto,
   CreateAccountDto,
+  LoginDto,
   PaginationFilterDto,
   PublicAccountDto,
   UpdateAccountDto,
@@ -30,6 +31,7 @@ import { ApiKeyGuard, SuperApiKeyGuard } from "./authGuard";
 import { ZodValidationPipe } from "nestjs-zod";
 import {
   CreateAccountSchema,
+  LoginSchema,
   PaginatedResponse,
   PaginationFilterSchema,
   UpdateAccountSchema,
@@ -47,10 +49,10 @@ export class AuthController {
    * @returns The Account and their ApiKey.
    */
   @ApiOperation({ summary: "Logs into an existing account." })
-  @UsePipes(new ZodValidationPipe(CreateAccountSchema))
+  @UsePipes(new ZodValidationPipe(LoginSchema))
   @Post("login")
   async loginAccount(
-    @Body() account: CreateAccountDto,
+    @Body() account: LoginDto,
   ): Promise<{ account: PublicAccountDto; apiKey: ApiKeyDto | null }> {
     return await this.authService.loginAccount(account);
   }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -4,6 +4,7 @@ import { AccountDatabaseService } from "../database/db.account.service";
 import { ApiKeyDatabaseService } from "../database/db.apiKey.service";
 import {
   CreateAccountDto,
+  LoginDto,
   PaginationFilterDto,
   UpdateAccountDto,
 } from "../dto/dto";
@@ -29,6 +30,7 @@ describe("AuthService", () => {
   const filter: PaginationFilterDto = {
     limit: 10,
     page: 1,
+    descending: true,
   };
 
   beforeEach(async () => {
@@ -73,7 +75,7 @@ describe("AuthService", () => {
 
   describe("loginAccount", () => {
     it("should login and return an account with api key", async () => {
-      const dto: CreateAccountDto = {
+      const dto: LoginDto = {
         username: "testuser",
         password: "password123",
       };
@@ -95,6 +97,7 @@ describe("AuthService", () => {
       const dto: CreateAccountDto = {
         username: "testuser",
         password: "password123",
+        superAdmin: false,
       };
       const mockAccount = { id: 10, username: "testuser", superAdmin: false };
       const mockApiKey = { id: 99, key: "super-secret-key" };
@@ -114,7 +117,6 @@ describe("AuthService", () => {
       expect(result).toEqual(mockAccount);
     });
   });
-
   describe("updateAccount", () => {
     it("should update and return the account", async () => {
       const dto: UpdateAccountDto = { id: 1, username: "updateduser" };

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -4,6 +4,7 @@ import { ApiKeyDatabaseService } from "../database/db.apiKey.service";
 import {
   ApiKeyDto,
   CreateAccountDto,
+  LoginDto,
   PaginationFilterDto,
   PublicAccountDto,
   UpdateAccountDto,
@@ -37,7 +38,7 @@ export class AuthService {
    * @returns An object containing the Account and ApiKey.
    */
   async loginAccount(
-    account: CreateAccountDto,
+    account: LoginDto,
   ): Promise<{ account: PublicAccountDto; apiKey: ApiKeyDto | null }> {
     return await this.accountDbService.loginAccount(account);
   }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -54,7 +54,9 @@ export class AuthService {
     const account: PublicAccountDto =
       await this.accountDbService.createAccount(createAccount);
 
-    const apiKey: ApiKeyDto = await this.apiKeyDbService.generateApiKey();
+    const apiKey: ApiKeyDto = await this.apiKeyDbService.generateApiKey(
+      createAccount.superAdmin,
+    );
     await this.accountDbService.linkAccountToKey(account.id, apiKey.id);
 
     return account;

--- a/backend/src/database/db.account.service.ts
+++ b/backend/src/database/db.account.service.ts
@@ -4,6 +4,7 @@ import {
   AccountDto,
   ApiKeyDto,
   CreateAccountDto,
+  LoginDto,
   PublicAccountDto,
   UpdateAccountDto,
 } from "../dto/dto";
@@ -102,7 +103,7 @@ export class AccountDatabaseService {
    * @throws InvalidCredentialsException if an incorrect password is provided (401)
    */
   async loginAccount(
-    account: CreateAccountDto,
+    account: LoginDto,
   ): Promise<{ account: PublicAccountDto; apiKey: ApiKeyDto | null }> {
     // 1. Fetch account by username
     const query = `

--- a/backend/src/database/db.account.service.ts
+++ b/backend/src/database/db.account.service.ts
@@ -72,8 +72,8 @@ export class AccountDatabaseService {
     const hashedPassword = await bcrypt.hash(account.password, 10);
 
     const query = `
-      INSERT INTO accounts (username, password)
-      VALUES ($1, $2)
+      INSERT INTO accounts (username, password, super_admin)
+      VALUES ($1, $2, $3)
       RETURNING id, username, super_admin AS "superAdmin"
     `;
 
@@ -81,6 +81,7 @@ export class AccountDatabaseService {
       const result = await this.db.query<PublicAccountDto>(query, [
         account.username,
         hashedPassword,
+        account.superAdmin,
       ]);
 
       return result[0];

--- a/backend/src/database/db.apiKey.service.ts
+++ b/backend/src/database/db.apiKey.service.ts
@@ -44,19 +44,20 @@ export class ApiKeyDatabaseService {
   /**
    * Generates, inserts the api key into the database and returns an api key.
    * This function should only be allowed to be used by a "superuser"
+   * @param superKey whether the generated key should be a super key or not. default: false
    * @returns the newly generated apiKey.
    */
-  async generateApiKey(): Promise<ApiKeyDto> {
+  async generateApiKey(superKey: boolean = false): Promise<ApiKeyDto> {
     // Generate secure random key
     const key = crypto.randomBytes(32).toString("hex");
 
     const query = `
-      INSERT INTO api_keys (key, active)
-      VALUES ($1, TRUE)
-      RETURNING id, key, active
+      INSERT INTO api_keys (key, active, super_key)
+      VALUES ($1, TRUE, $2)
+      RETURNING id, key, active, super_key
     `;
 
-    const result = await this.db.query<ApiKeyDto>(query, [key]);
+    const result = await this.db.query<ApiKeyDto>(query, [key, superKey]);
 
     return result[0];
   }

--- a/backend/src/dto/dto.ts
+++ b/backend/src/dto/dto.ts
@@ -25,6 +25,7 @@ import {
   LanguageQuerySchema,
   LocationSchema,
   LocationViewSchema,
+  LoginSchema,
   MediaCropSchema,
   MediaGallerySchema,
   MediaItemSchema,
@@ -116,6 +117,7 @@ export class ReplacePriceDto extends createZodDto(ReplacePriceSchema) {}
 
 // Account Wrapper
 export class CreateAccountDto extends createZodDto(CreateAccountSchema) {}
+export class LoginDto extends createZodDto(LoginSchema) {}
 export class UpdateAccountDto extends createZodDto(UpdateAccountSchema) {}
 export class PublicAccountDto extends createZodDto(PublicAccountSchema) {}
 export class AccountDto extends createZodDto(AccountSchema) {}

--- a/common/src/objects/accounts.ts
+++ b/common/src/objects/accounts.ts
@@ -11,7 +11,6 @@ export const AccountSchema = z.object({
 // Updating & Creating
 export const CreateAccountSchema = AccountSchema.omit({
   id: true,
-  superAdmin: true,
 });
 export const UpdateAccountSchema = AccountSchema.partial();
 

--- a/common/src/objects/accounts.ts
+++ b/common/src/objects/accounts.ts
@@ -12,6 +12,10 @@ export const AccountSchema = z.object({
 export const CreateAccountSchema = AccountSchema.omit({
   id: true,
 });
+export const LoginSchema = AccountSchema.pick({
+  username: true,
+  password: true,
+});
 export const UpdateAccountSchema = AccountSchema.partial();
 
 // Public Account object.
@@ -21,6 +25,7 @@ export const PublicAccountSchema = AccountSchema.omit({
 
 // Type exports.
 export type CreateAccount = z.infer<typeof CreateAccountSchema>;
+export type LoginAccount = z.infer<typeof LoginSchema>;
 export type UpdateAccount = z.infer<typeof UpdateAccountSchema>;
 export type PublicAccount = z.infer<typeof PublicAccountSchema>;
 export type Account = z.infer<typeof AccountSchema>;

--- a/frontend/app/components/admin/AccountForm.vue
+++ b/frontend/app/components/admin/AccountForm.vue
@@ -21,14 +21,14 @@ import { computed } from "vue";
 import type { CreateAccount } from "@repo/common";
 import type { FormField } from "../../types/FormField";
 
-// type AccountRole = "Admin" | "Super Admin";
+type AccountRole = "Admin" | "Super Admin";
 
 const { t } = useI18n();
 interface AccountFormModel {
   username: string;
   password: string;
   confirmPassword: string;
-  // role: AccountRole;
+  role: AccountRole;
 }
 
 const props = withDefaults(
@@ -40,7 +40,7 @@ const props = withDefaults(
       username: "",
       password: "",
       confirmPassword: "",
-      // role: "Admin" as AccountRole,
+      role: "Admin" as AccountRole,
     }),
   },
 );
@@ -88,7 +88,6 @@ const fields = computed<FormField[]>(() => [
       minLength: 8, // enforce minimum length for better security, can be adjusted as needed
     },
   },
-  /*
   {
     component: "BaseSelect",
     name: "role",
@@ -98,7 +97,6 @@ const fields = computed<FormField[]>(() => [
       required: true,
     },
   },
-  */
 ]);
 
 function handleFormSubmit(formData: Record<string, any>) {
@@ -114,7 +112,7 @@ function handleFormSubmit(formData: Record<string, any>) {
   const payload: CreateAccount = {
     username: String(formData.username ?? ""),
     password: String(formData.password ?? ""),
-    // superAdmin: formData.role === "Super Admin",
+    superAdmin: formData.role === "Super Admin",
   };
 
   emit("submit", payload);

--- a/frontend/app/components/admin/AccountForm.vue
+++ b/frontend/app/components/admin/AccountForm.vue
@@ -93,7 +93,10 @@ const fields = computed<FormField[]>(() => [
     name: "role",
     props: {
       label: t("accounts.role"),
-      options: [t("accounts.admin"), t("accounts.superAdmin")],
+      options: [
+        { label: t("accounts.admin"), value: "Admin" },
+        { label: t("accounts.superAdmin"), value: "Super Admin" },
+      ],
       required: true,
     },
   },

--- a/frontend/tests/components/form/AccountForm.spec.ts
+++ b/frontend/tests/components/form/AccountForm.spec.ts
@@ -62,7 +62,7 @@ describe("AccountForm", () => {
       props?: Record<string, unknown>;
     }>;
 
-    expect(fields).toHaveLength(3);
+    expect(fields).toHaveLength(4);
     expect(fields[0]?.name).toBe("username");
     expect(fields[0]?.props?.label).toBe("Username");
     expect(fields[0]?.props?.placeholder).toBe("Enter a username");
@@ -72,6 +72,7 @@ describe("AccountForm", () => {
     expect(fields[2]?.name).toBe("confirmPassword");
     expect(fields[2]?.props?.label).toBe("Confirm password");
     expect(fields[2]?.props?.placeholder).toBe("Repeat your password");
+    expect(fields[3]?.name).toBe("role");
   });
 
   it("updates translated labels when locale changes", async () => {
@@ -115,6 +116,7 @@ describe("AccountForm", () => {
     expect(wrapper.emitted("submit")?.[0]?.[0]).toEqual({
       username: "admin-user",
       password: "secret123",
+      superAdmin: false,
     });
   });
 


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature
* adds the posibility to create multiple super admins
* To do this, some auth schemes and services/controllers were changed to have superkey/superadmin in the accounts

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed


## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code


## 🔍 HOW TO TEST
1. Log in as a super admin
2. Check if you can now create other super admins
3. Log into the other super admin and see if they can so super admin things
(superadmins can't be deleted via frontend so don't clutter the database that much, ideally do it on dev)

## ⚠️ REMAINING ISSUES

## 📸 SCREENSHOTS (if necessary):

## ✅ CLOSED ISSUES
- Closes #477 
