### PR TITLE
Series Filter for Title and Production ID

### DIFF
--- a/backend/src/database/db.series.service.ts
+++ b/backend/src/database/db.series.service.ts
@@ -2,18 +2,21 @@ import { BadRequestException, Injectable } from "@nestjs/common";
 import { DbService } from "./db.service";
 import {
   executeWithReferenceCheck,
-  generateCountQuery,
   generateInsertClause,
+  generateRelevanceClause,
   generateReturningClause,
   generateUpdateClause,
 } from "./db-utils";
 import {
+  Language,
   PaginatedResponse,
   ProductionSchema,
   SeriesSchema,
+  SUPPORTED_LANGUAGES,
 } from "@repo/common";
 import {
   CreateSeriesDto,
+  FilterSeriesDto,
   ModifySeriesDto,
   PaginationFilterDto,
   ProductionDto,
@@ -57,33 +60,97 @@ export class SeriesDatabaseService {
   /**
    * Get series with pagination
    * @param paginationFilters are the filters you want to use in the pagination.
+   * @param seriesFilters The filters used for series.
    * @return prices
    */
   async getSeries(
     paginationFilters: PaginationFilterDto,
+    seriesFilters: FilterSeriesDto,
+    language?: Language,
   ): Promise<PaginatedResponse<SeriesDto>> {
     const returningClause = generateReturningClause(SeriesSchema);
+
+    const conditions: string[] = [];
+    const values: (string | number)[] = [];
+    const param = (val: string | number) => {
+      values.push(val);
+      return `$${values.length}`;
+    };
+
+    // Title filter
+    // Looks into the language provided and filters differently based on
+    // Whether the query is a suggestion or not.
+    if (seriesFilters.title) {
+      const searchTerm = seriesFilters.title;
+
+      const allClauses = SUPPORTED_LANGUAGES.flatMap((lang) => {
+        if (language && language !== lang) return [];
+
+        const titleField = `titel->>'${lang}'`;
+
+        if (seriesFilters.is_suggestion) {
+          const pSearch = param(searchTerm);
+          return [`word_similarity(${pSearch}, ${titleField}) > 0.3`];
+        } else {
+          const pSearch = param(`%${searchTerm}%`);
+          return [`${titleField} ILIKE ${pSearch}`];
+        }
+      });
+
+      // Push them as a single string wrapped in parentheses, joined by OR
+      if (allClauses.length > 0) {
+        conditions.push(`(${allClauses.join(" OR ")})`);
+      }
+    }
+
+    const whereClause = conditions.length
+      ? `WHERE ${conditions.join(" AND ")}`
+      : "";
+
+    const filterValues = [...values];
+    const countQuery = `
+      SELECT COUNT(*) as count FROM series
+      ${whereClause};
+    `;
+
+    // pagination
+    const offset = paginationFilters.page * paginationFilters.limit;
+    const paginationClause = `LIMIT ${param(paginationFilters.limit)} OFFSET ${param(offset)}`;
+
+    // Ordering (relevance vs date)
+    let orderClause: string;
+    if (seriesFilters.is_suggestion && seriesFilters.title) {
+      const relevanceMath = generateRelevanceClause(
+        seriesFilters.title,
+        [{ name: `titel` }],
+        param,
+        language,
+      );
+
+      orderClause = `ORDER BY ${relevanceMath} DESC`;
+    } else {
+      orderClause = `ORDER BY created_at ${paginationFilters.descending ? "DESC" : "ASC"}`;
+    }
 
     const query = `
       SELECT ${returningClause}
       FROM series
-      ORDER BY id
-      LIMIT $1 OFFSET $2;
+      ${whereClause}
+      ${orderClause}
+      ${paginationClause};
     `;
-    const countQuery = generateCountQuery("series");
 
-    const offset = paginationFilters.page * paginationFilters.limit;
-
-    const [prices, countResult] = await Promise.all([
-      this.db.query<SeriesDto>(query, [paginationFilters.limit, offset]),
-      this.db.query<{ count: string }>(countQuery),
+    // Fetch count and objects.
+    const [objects, countResult] = await Promise.all([
+      this.db.query<SeriesDto>(query, values),
+      this.db.query<{ count: string }>(countQuery, filterValues),
     ]);
 
     return {
       page: paginationFilters.page,
       limit: paginationFilters.limit,
       totalItems: parseInt(countResult[0].count),
-      objects: prices,
+      objects: objects,
     };
   }
 

--- a/backend/src/database/db.series.service.ts
+++ b/backend/src/database/db.series.service.ts
@@ -61,6 +61,7 @@ export class SeriesDatabaseService {
    * Get series with pagination
    * @param paginationFilters are the filters you want to use in the pagination.
    * @param seriesFilters The filters used for series.
+   * @param language Optional language param that'll be used to choose what field to filter by.
    * @return prices
    */
   async getSeries(

--- a/backend/src/database/db.series.service.ts
+++ b/backend/src/database/db.series.service.ts
@@ -77,6 +77,17 @@ export class SeriesDatabaseService {
       return `$${values.length}`;
     };
 
+    // Filter by production to get all series that contain a certain production.
+    if (seriesFilters.production_id) {
+      conditions.push(
+        `EXISTS (
+          SELECT 1 FROM production_series ps
+          WHERE ps.series_id = series.id 
+          AND ps.production_id = ${param(seriesFilters.production_id)}
+        )`,
+      );
+    }
+
     // Title filter
     // Looks into the language provided and filters differently based on
     // Whether the query is a suggestion or not.

--- a/backend/src/dto/dto.ts
+++ b/backend/src/dto/dto.ts
@@ -21,6 +21,7 @@ import {
   FilterLocationSchema,
   FilterPrintItemSchema,
   FilterProductionSchema,
+  FilterSeriesSchema,
   FilterTagSchema,
   LanguageQuerySchema,
   LocationSchema,
@@ -167,6 +168,7 @@ export class SeriesViewDto extends createZodDto(SeriesViewSchema) {}
 export class CreateSeriesDto extends createZodDto(CreateSeriesSchema) {}
 export class ModifySeriesDto extends createZodDto(ModifySeriesSchema) {}
 export class ReplaceSeriesDto extends createZodDto(ReplaceSeriesSchema) {}
+export class FilterSeriesDto extends createZodDto(FilterSeriesSchema) {}
 
 // CSV Upload DTO
 export class ParserUploadCsvBodyDto {

--- a/backend/src/series/series.controller.spec.ts
+++ b/backend/src/series/series.controller.spec.ts
@@ -69,10 +69,20 @@ describe("SeriesController", () => {
     it("should return paginated series and flatten by language", async () => {
       mockSeriesService.getSeries.mockResolvedValue(mockPaginatedSeries);
 
-      const result = await controller.getSeries(mockLang, mockPaginationFilter);
+      const result = await controller.getSeries(
+        mockLang,
+        mockPaginationFilter,
+        { is_suggestion: false },
+      );
 
       expect(result).toEqual(mockPaginatedSeries);
-      expect(service.getSeries).toHaveBeenCalledWith(mockPaginationFilter);
+      expect(service.getSeries).toHaveBeenCalledWith(
+        mockPaginationFilter,
+        {
+          is_suggestion: false,
+        },
+        mockLang.lang,
+      );
       expect(languageService.flattenByLanguage).toHaveBeenCalledWith(
         mockPaginatedSeries,
         mockLang.lang,

--- a/backend/src/series/series.controller.ts
+++ b/backend/src/series/series.controller.ts
@@ -15,6 +15,7 @@ import {
 import { SeriesService } from "./series.service";
 import {
   CreateSeriesDto,
+  FilterSeriesDto,
   LanguageQueryDto,
   ModifySeriesDto,
   PaginationFilterDto,
@@ -34,6 +35,7 @@ import { ApiKeyGuard } from "../auth/authGuard";
 import { ZodValidationPipe } from "nestjs-zod";
 import {
   CreateSeriesSchema,
+  FilterSeriesSchema,
   LanguageQuerySchema,
   ModifySeriesSchema,
   PaginatedResponse,
@@ -57,6 +59,7 @@ export class SeriesController {
    * Responds to GET /series
    * @param lang is the language filter
    * @param paginationFilter is the pagination parameters.
+   * @param seriesFilters filtering for series.
    * @returns Paginated SeriesDto objects
    */
   @ApiOperation({ summary: "Returns a paginated list of Series." })
@@ -66,10 +69,19 @@ export class SeriesController {
     @Query(new ZodValidationPipe(LanguageQuerySchema)) lang: LanguageQueryDto,
     @Query(new ZodValidationPipe(PaginationFilterSchema))
     paginationFilter: PaginationFilterDto,
+    @Query(new ZodValidationPipe(FilterSeriesSchema))
+    seriesFilters: FilterSeriesDto,
   ): Promise<PaginatedResponse<SeriesDto | SeriesViewDto>> {
     return this.ls.flattenByLanguage<
       PaginatedResponse<SeriesDto | SeriesViewDto>
-    >(await this.seriesService.getSeries(paginationFilter), lang.lang);
+    >(
+      await this.seriesService.getSeries(
+        paginationFilter,
+        seriesFilters,
+        lang.lang,
+      ),
+      lang.lang,
+    );
   }
 
   /**

--- a/backend/src/series/series.service.spec.ts
+++ b/backend/src/series/series.service.spec.ts
@@ -77,9 +77,21 @@ describe("SeriesService", () => {
   describe("getSeries", () => {
     it("should fetch a paginated list of series", async () => {
       mockSeriesDbService.getSeries.mockResolvedValue(mockPaginatedSeries);
-      const result = await service.getSeries(mockPaginationFilter);
+      const result = await service.getSeries(
+        mockPaginationFilter,
+        {
+          is_suggestion: false,
+        },
+        undefined,
+      );
       expect(result).toEqual(mockPaginatedSeries);
-      expect(dbService.getSeries).toHaveBeenCalledWith(mockPaginationFilter);
+      expect(dbService.getSeries).toHaveBeenCalledWith(
+        mockPaginationFilter,
+        {
+          is_suggestion: false,
+        },
+        undefined,
+      );
     });
   });
 

--- a/backend/src/series/series.service.ts
+++ b/backend/src/series/series.service.ts
@@ -27,7 +27,8 @@ export class SeriesService {
   /**
    * Fetches a paginated list of series.
    * @param paginationFilters The filters to paginate by.
-   * @param seriesFilters The filters for series.
+   * @param seriesFilters The filters for series
+   * @param language Optional language param that'll be used to choose what field to filter by.
    * @returns Paginated list of series.
    */
   async getSeries(

--- a/backend/src/series/series.service.ts
+++ b/backend/src/series/series.service.ts
@@ -2,13 +2,14 @@ import { Injectable } from "@nestjs/common";
 import { SeriesDatabaseService } from "../database/db.series.service";
 import {
   CreateSeriesDto,
+  FilterSeriesDto,
   ModifySeriesDto,
   PaginationFilterDto,
   ProductionDto,
   ReplaceSeriesDto,
   SeriesDto,
 } from "../dto/dto";
-import { PaginatedResponse } from "@repo/common";
+import { Language, PaginatedResponse } from "@repo/common";
 
 @Injectable()
 export class SeriesService {
@@ -26,12 +27,19 @@ export class SeriesService {
   /**
    * Fetches a paginated list of series.
    * @param paginationFilters The filters to paginate by.
+   * @param seriesFilters The filters for series.
    * @returns Paginated list of series.
    */
   async getSeries(
     paginationFilters: PaginationFilterDto,
+    seriesFilters: FilterSeriesDto,
+    language?: Language,
   ): Promise<PaginatedResponse<SeriesDto>> {
-    return await this.seriesDbService.getSeries(paginationFilters);
+    return await this.seriesDbService.getSeries(
+      paginationFilters,
+      seriesFilters,
+      language,
+    );
   }
 
   /**

--- a/common/src/objects/series.ts
+++ b/common/src/objects/series.ts
@@ -29,6 +29,11 @@ export const CreateSeriesSchema = MutableSeriesSchema;
 export const ModifySeriesSchema = MutableSeriesSchema.partial();
 export const ReplaceSeriesSchema = MutableSeriesSchema;
 
+// Filtering.
+export const FilterSeriesSchema = z.object({
+  title: z.string().optional(),
+});
+
 // Type exports.
 export type Series = z.infer<typeof SeriesSchema>;
 export type SeriesView = z.infer<typeof SeriesViewSchema>;

--- a/common/src/objects/series.ts
+++ b/common/src/objects/series.ts
@@ -45,3 +45,4 @@ export type SeriesView = z.infer<typeof SeriesViewSchema>;
 export type CreateSeries = z.infer<typeof CreateSeriesSchema>;
 export type ModifySeries = z.infer<typeof ModifySeriesSchema>;
 export type ReplaceSeries = z.infer<typeof ReplaceSeriesSchema>;
+export type FilterSeries = z.infer<typeof FilterSeriesSchema>;

--- a/common/src/objects/series.ts
+++ b/common/src/objects/series.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { LocalizedStringSchema } from "./language";
+import { QueryBoolean } from "./pagination";
 
 // Base Series object.
 export const SeriesSchema = z.object({
@@ -32,6 +33,10 @@ export const ReplaceSeriesSchema = MutableSeriesSchema;
 // Filtering.
 export const FilterSeriesSchema = z.object({
   title: z.string().optional(),
+  production_id: z.number().optional(),
+
+  // Toggle for the backend to treat this request as a suggestion.
+  is_suggestion: QueryBoolean.default(false),
 });
 
 // Type exports.

--- a/common/src/objects/series.ts
+++ b/common/src/objects/series.ts
@@ -33,7 +33,7 @@ export const ReplaceSeriesSchema = MutableSeriesSchema;
 // Filtering.
 export const FilterSeriesSchema = z.object({
   title: z.string().optional(),
-  production_id: z.number().optional(),
+  production_id: z.coerce.number().optional(),
 
   // Toggle for the backend to treat this request as a suggestion.
   is_suggestion: QueryBoolean.default(false),

--- a/frontend/app/composables/useSeriesApi.ts
+++ b/frontend/app/composables/useSeriesApi.ts
@@ -10,12 +10,14 @@ import type {
   ReplaceSeries,
   Series,
   SeriesView,
+  FilterSeries,
 } from "@repo/common";
 import { API_ROUTES } from "~/utils/apiRoutes";
 import { buildQueryString } from "~/utils/formatters";
 
 interface SeriesListOptions {
   paginationFilters?: PaginationFilter;
+  seriesFilters?: FilterSeries;
   languageFilters?: LanguageQuery;
 }
 
@@ -34,16 +36,23 @@ export function useSeriesApi() {
    */
   function getAll(options?: {
     paginationFilters?: PaginationFilter;
+    seriesFilters?: FilterSeries;
   }): Promise<ApiResponse<PaginatedResponse<Series>>>;
   function getAll(options: {
     paginationFilters?: PaginationFilter;
+    seriesFilters?: FilterSeries;
     languageFilters: LanguageQuery;
   }): Promise<ApiResponse<PaginatedResponse<SeriesView>>>;
   function getAll({
     paginationFilters,
+    seriesFilters,
     languageFilters,
   }: SeriesListOptions = {}) {
-    const params = { ...paginationFilters, ...languageFilters };
+    const params = {
+      ...paginationFilters,
+      ...languageFilters,
+      ...seriesFilters,
+    };
     const query = buildQueryString(params);
 
     return get<PaginatedResponse<Series | SeriesView>>(


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature

### Changelog

* Series Composable and backend endpoint now supports filters by `title` and `production_id`. The latter will return all series that contain a certain production.
 
## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code
- [x] external documentation (README, etc.) has been changed

## 🔍 HOW TO TEST

You can test this on Swagger but also when using it in the frontend.

## ✅ CLOSED ISSUES
- Closes #492
