### PR TITLE
Show Production on Blog Detail & Blog Back Fix

### DIFF
--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -137,6 +137,17 @@ export class ProductionDatabaseService {
       productionPrefix,
     );
 
+    // Filter by blog to get all productions that contain a certain blog.
+    if (productionFilters.blog_id) {
+      conditions.push(
+        `EXISTS (
+          SELECT 1 FROM production_blogs pb
+          WHERE pb.production_id = p.id 
+          AND pb.blog_id = ${param(productionFilters.blog_id)}
+        )`,
+      );
+    }
+
     // Filter by either artist or title. The trgm extension in psql
     if (productionFilters.titelOrArtist) {
       const searchTerm = productionFilters.titelOrArtist;

--- a/common/src/objects/productions.ts
+++ b/common/src/objects/productions.ts
@@ -62,6 +62,9 @@ export const FilterProductionSchema = z.object({
   performer_type: z.string().optional(),
   attendance_mode: z.string().optional(),
 
+  // This will return all productions that are tied to the blog.
+  blog_id: z.coerce.number().optional(),
+
   // Toggle for the backend to treat the request as a suggestion.
   is_suggestion: QueryBoolean.default(false),
 });

--- a/frontend/app/assets/css/tailwind.css
+++ b/frontend/app/assets/css/tailwind.css
@@ -522,6 +522,10 @@
     @apply mt-4 max-w-xl;
     @apply font-brand font-black text-[10px] sm:text-[11px] uppercase tracking-widest text-muted-foreground;
   }
+
+  .subtitle {
+    @apply font-brand font-black text-xl lg:text-2xl uppercase tracking-tighter italic text-foreground;
+  }
 }
 /* ── Calendar component ──────────────────────────────────────────────────────
    Used by components/calendar.vue + components/calendar/*.vue

--- a/frontend/app/components/production/ProductionGallery.vue
+++ b/frontend/app/components/production/ProductionGallery.vue
@@ -37,7 +37,7 @@ const setSlide = (index: number) => {
         v-if="images.length > 1"
         @click="prevSlide"
         class="shrink-0 text-foreground/40 hover:text-accent p-2 rounded-full transition-colors outline-none"
-        aria-label="Vorige afbeelding"
+        :aria-label="t('production.gallery_nav.prev')"
       >
         <ChevronLeft :size="28" stroke-width="2.5" />
       </button>
@@ -69,7 +69,9 @@ const setSlide = (index: number) => {
             :class="
               currentSlide === index ? 'bg-white w-6' : 'bg-white/40 w-1.5'
             "
-            :aria-label="`Ga naar dia ${index + 1}`"
+            :aria-label="
+              t('production.gallery_nav.go_to_slide', { slide: index + 1 })
+            "
           ></button>
         </div>
       </div>
@@ -78,7 +80,7 @@ const setSlide = (index: number) => {
         v-if="images.length > 1"
         @click="nextSlide"
         class="shrink-0 text-foreground/40 hover:text-accent p-2 rounded-full transition-colors outline-none"
-        aria-label="Volgende afbeelding"
+        aria-label="t('production.gallery_nav.next')"
       >
         <ChevronRight :size="28" stroke-width="2.5" />
       </button>

--- a/frontend/app/components/production/ProductionGallery.vue
+++ b/frontend/app/components/production/ProductionGallery.vue
@@ -31,34 +31,34 @@ const setSlide = (index: number) => {
 <template>
   <div class="w-full">
     <div
-      class="relative group overflow-hidden rounded-2xl bg-gray-100 dark:bg-white/5"
+      class="flex items-center gap-2 sm:gap-4 md:gap-6 px-4 sm:px-12 md:px-16"
     >
-      <div class="aspect-[2/1] w-full overflow-hidden">
-        <MediaDisplay
-          :id="productionId"
-          :src="images[currentSlide] ?? null"
-          size="fill"
-          :rounded="false"
-          class="w-full h-full object-cover"
-        />
-      </div>
+      <button
+        v-if="images.length > 1"
+        @click="prevSlide"
+        class="shrink-0 text-foreground/40 hover:text-accent p-2 rounded-full transition-colors outline-none"
+        aria-label="Vorige afbeelding"
+      >
+        <ChevronLeft :size="28" stroke-width="2.5" />
+      </button>
 
-      <template v-if="images.length > 1">
-        <button
-          @click="prevSlide"
-          class="absolute left-4 top-1/2 -translate-y-1/2 z-10 bg-black/30 hover:bg-black/50 backdrop-blur-sm text-white p-2 rounded-full transition-all opacity-0 group-hover:opacity-100"
+      <div
+        class="flex-1 relative overflow-hidden rounded-2xl bg-gray-100 dark:bg-white/5"
+      >
+        <div
+          class="aspect-[16/9] w-full overflow-hidden flex items-center justify-center"
         >
-          <ChevronLeft :size="24" />
-        </button>
-
-        <button
-          @click="nextSlide"
-          class="absolute right-4 top-1/2 -translate-y-1/2 z-10 bg-black/30 hover:bg-black/50 backdrop-blur-sm text-white p-2 rounded-full transition-all opacity-0 group-hover:opacity-100"
-        >
-          <ChevronRight :size="24" />
-        </button>
+          <MediaDisplay
+            :id="productionId"
+            :src="images[currentSlide] ?? null"
+            size="fill"
+            :rounded="false"
+            class="w-full h-full object-contain"
+          />
+        </div>
 
         <div
+          v-if="images.length > 1"
           class="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex gap-2"
         >
           <button
@@ -69,9 +69,19 @@ const setSlide = (index: number) => {
             :class="
               currentSlide === index ? 'bg-white w-6' : 'bg-white/40 w-1.5'
             "
+            :aria-label="`Ga naar dia ${index + 1}`"
           ></button>
         </div>
-      </template>
+      </div>
+
+      <button
+        v-if="images.length > 1"
+        @click="nextSlide"
+        class="shrink-0 text-foreground/40 hover:text-accent p-2 rounded-full transition-colors outline-none"
+        aria-label="Volgende afbeelding"
+      >
+        <ChevronRight :size="28" stroke-width="2.5" />
+      </button>
     </div>
 
     <div class="mt-4 flex justify-center">

--- a/frontend/app/components/production/ProductionGallery.vue
+++ b/frontend/app/components/production/ProductionGallery.vue
@@ -29,11 +29,7 @@ const setSlide = (index: number) => {
 </script>
 
 <template>
-  <div v-if="images && images.length > 0" class="my-16">
-    <h2 class="text-[16px] uppercase font-black mb-6 tracking-widest">
-      {{ t("production.gallery") }}
-    </h2>
-
+  <div class="w-full">
     <div
       class="relative group overflow-hidden rounded-2xl bg-gray-100 dark:bg-white/5"
     >

--- a/frontend/app/pages/productions/[id].vue
+++ b/frontend/app/pages/productions/[id].vue
@@ -316,9 +316,9 @@ onBeforeUnmount(() => {
         </div>
 
         <div class="mt-12 mb-16">
-          <h1 class="text-[16px] uppercase font-black mb-6 tracking-widest">
+          <h2 class="subtitle mb-4">
             {{ t("production.events") }}
-          </h1>
+          </h2>
           <ProductionEventTable
             v-if="events && events.length > 0"
             :events="events"
@@ -349,17 +349,21 @@ onBeforeUnmount(() => {
         </div>
 
         <div v-if="stories && stories.length > 0" class="my-16">
-          <h1 class="text-[16px] uppercase font-black mb-6 tracking-widest">
+          <h2 class="subtitle mb-4">
             {{ t("production.stories") }}
-          </h1>
+          </h2>
           <ProductionStoryListView :stories="stories" />
         </div>
 
-        <ProductionGallery
-          v-if="carouselImages.length > 0"
-          :images="carouselImages"
-          :production-id="production.id"
-        />
+        <div v-if="carouselImages && carouselImages.length > 0" class="my-16">
+          <h2 class="subtitle mb-4">
+            {{ t("production.gallery") }}
+          </h2>
+          <ProductionGallery
+            :images="carouselImages"
+            :production-id="production.id"
+          />
+        </div>
 
         <div
           v-if="isValid(production.credits)"

--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -31,6 +31,7 @@ const { t, locale } = useI18n();
 const { getMainImageCrop } = useGallery();
 const { getById, getMediaGallery } = useBlogApi();
 const { useBlogStory } = useBlogView();
+const router = useRouter();
 
 /** validation that id is only numbers */
 definePageMeta({
@@ -41,6 +42,15 @@ definePageMeta({
     return /^\d+$/.test(raw as string);
   },
 });
+
+// Let's you go back to the previous page!
+const goBack = () => {
+  if (window.history.length > 1) {
+    router.back();
+  } else {
+    router.push(ROUTES.stories.base); // Fallback
+  }
+};
 
 /** Parse the blog ID from the URL, returning null for non-numeric values. */
 const blogId = computed(() => {
@@ -251,14 +261,14 @@ watch(title, updateTitleScrollable);
         <div class="relative z-10 page-container pb-12">
           <!-- Back link + reading time row -->
           <div class="flex items-center gap-6 mb-8">
-            <NuxtLink
+            <button
               :class="headerCrop ? 'text-white' : 'text-foreground'"
-              :to="ROUTES.stories.base"
               class="flex items-center gap-1 text-[11px] font-black uppercase tracking-[2px] hover:text-accent transition-colors"
+              @click="goBack()"
             >
               <ChevronLeft :size="14" stroke-width="3" />
               {{ t("general.back") }}
-            </NuxtLink>
+            </button>
 
             <span
               :class="headerCrop ? 'text-white' : 'text-foreground'"

--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -22,6 +22,7 @@ import { ChevronLeft } from "lucide-vue-next";
 import type { BlogView, MediaItemView } from "@repo/common";
 import { cleanText } from "~/utils/formatters";
 import { useBlogApi } from "~/composables/blogs/useBlogApi";
+import { useProductionApi } from "~/composables/useProductionApi";
 import { useGallery } from "~/composables/media/useGallery";
 import { ROUTES } from "~/utils/routes";
 import { useBlogView } from "~/composables/blogs/useBlogView";
@@ -30,6 +31,7 @@ const route = useRoute();
 const { t, locale } = useI18n();
 const { getMainImageCrop } = useGallery();
 const { getById, getMediaGallery } = useBlogApi();
+const { getAll: getProductions } = useProductionApi();
 const { useBlogStory } = useBlogView();
 const router = useRouter();
 
@@ -105,6 +107,52 @@ const { data: gallery } = useAsyncData(
     return (res as any)?.data ?? res;
   },
   { watch: [blogId, locale] },
+);
+
+/** Pagination state and logic for the "Show All" button.*/
+
+const LINKED_PRODUCTIONS_LIMIT = 3;
+const currentLimit = ref(LINKED_PRODUCTIONS_LIMIT);
+const totalLinkedProductions = ref(0);
+
+const hasMore = computed(() => {
+  return linkedProductions.value.length < totalLinkedProductions.value;
+});
+
+const loadMoreProductions = () => {
+  currentLimit.value = totalLinkedProductions.value;
+};
+
+/** Fetch linked productions using the blog_id filter */
+const { data: linkedProductions, status: productionsStatus } = useAsyncData(
+  `blog-productions-${blogId.value}-${locale.value}`,
+  async () => {
+    if (!blogId.value) return [];
+
+    try {
+      const resp = await getProductions({
+        productionFilters: {
+          blog_id: blogId.value,
+        },
+        paginationFilters: {
+          page: 0,
+          limit: currentLimit.value,
+          descending: false,
+        },
+        languageFilters: {
+          lang: locale.value as any,
+        },
+      });
+
+      const unwrapped = (resp as any)?.data ?? resp;
+      totalLinkedProductions.value = unwrapped?.totalItems ?? 0;
+      return unwrapped?.objects ?? [];
+    } catch (err) {
+      console.error("Failed to load related productions:", err);
+      return [];
+    }
+  },
+  { watch: [blogId, locale, currentLimit], default: () => [] },
 );
 
 // Derived values
@@ -367,25 +415,86 @@ watch(title, updateTitleScrollable);
                   {{ imageCredits }}
                 </p>
               </div>
-
-              <!-- Article footer: date + back link -->
-              <div
-                class="mt-16 pt-8 border-t flex items-center justify-between border-gray-200 dark:border-[#2e3347]"
-              >
-                <span
-                  class="font-brand font-black text-[9px] uppercase tracking-widest text-gray-400 dark:text-gray-500"
-                >
-                  {{ formattedDate }}
-                </span>
-                <NuxtLink
-                  :to="ROUTES.stories.base"
-                  class="flex items-center gap-1.5 px-4 py-2 rounded border font-brand font-black text-[9px] uppercase tracking-widest transition-all duration-150 border-gray-300 text-gray-600 hover:text-accent dark:border-[#2e3347] dark:text-gray-400"
-                >
-                  <ChevronLeft :size="12" /> {{ t("general.back") }}
-                </NuxtLink>
-              </div>
             </div>
           </article>
+        </div>
+      </section>
+      <section
+        v-if="productionsStatus === 'pending' && linkedProductions.length === 0"
+        class="page-container py-10 flex justify-center"
+      >
+        <svg
+          class="w-6 h-6 animate-spin text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M21 12a9 9 0 1 1-6.219-8.56"
+            stroke="currentColor"
+            stroke-width="2"
+          />
+        </svg>
+      </section>
+
+      <section
+        v-else-if="linkedProductions && linkedProductions.length > 0"
+        class="page-container pb-10 border-t border-gray-100 dark:border-[#2e3347]/30 pt-10"
+      >
+        <div class="mb-6">
+          <h2
+            class="font-brand font-black text-2xl lg:text-3xl uppercase tracking-tighter italic text-foreground"
+          >
+            {{ t("stories.relatedProductions", "Gerelateerde voorstellingen") }}
+          </h2>
+        </div>
+
+        <div
+          class="flex flex-col gap-4 mb-6 transition-all duration-500 ease-in-out"
+        >
+          <ProductionListViewItem
+            v-for="production in linkedProductions"
+            :key="production.id"
+            :productionView="production"
+            :is-admin="false"
+          />
+        </div>
+
+        <div v-if="hasMore" class="flex justify-center mt-8">
+          <button
+            class="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded font-brand font-black text-[10px] uppercase tracking-widest transition-all duration-300 hover:bg-gray-50 dark:hover:bg-white/5 outline-none"
+            :disabled="productionsStatus === 'pending'"
+            @click="loadMoreProductions"
+          >
+            <span v-if="productionsStatus === 'pending'">{{
+              t("general.loading", "Laden...")
+            }}</span>
+            <span v-else>{{
+              t("general.showAll", "Toon alle voorstellingen")
+            }}</span>
+          </button>
+        </div>
+      </section>
+
+      <section class="pb-20">
+        <div class="page-container">
+          <div class="md:pl-10 w-full">
+            <!-- Article footer: date + back link -->
+            <div
+              class="pt-8 border-t flex items-center justify-between border-gray-200 dark:border-[#2e3347]"
+            >
+              <span
+                class="font-brand font-black text-[9px] uppercase tracking-widest text-gray-400 dark:text-gray-500"
+              >
+                {{ formattedDate }}
+              </span>
+              <NuxtLink
+                :to="ROUTES.stories.base"
+                class="flex items-center gap-1.5 px-4 py-2 rounded border font-brand font-black text-[9px] uppercase tracking-widest transition-all duration-150 border-gray-300 text-gray-600 hover:text-accent dark:border-[#2e3347] dark:text-gray-400"
+              >
+                <ChevronLeft :size="12" /> {{ t("general.back") }}
+              </NuxtLink>
+            </div>
+          </div>
         </div>
       </section>
     </template>

--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -439,16 +439,14 @@ watch(title, updateTitleScrollable);
 
       <section
         v-else-if="linkedProductions && linkedProductions.length > 0"
-        class="page-container pb-14 border-t border-gray-100 dark:border-[#2e3347]/30 pt-10"
+        class="page-container pb-14 pt-10"
       >
         <div class="md:pl-10 w-full">
           <div class="mb-6">
             <h2
               class="font-brand font-black text-2xl lg:text-3xl uppercase tracking-tighter italic text-foreground"
             >
-              {{
-                t("stories.relatedProductions", "Gerelateerde voorstellingen")
-              }}
+              {{ t("stories.relatedProductions") }}
             </h2>
           </div>
 
@@ -470,11 +468,11 @@ watch(title, updateTitleScrollable);
               @click="loadMoreProductions"
             >
               <span v-if="productionsStatus === 'pending'">{{
-                t("general.loading", "Laden...")
+                t("stories.loading")
               }}</span>
-              <span v-else>{{
-                t("general.showAll", "Toon alle voorstellingen")
-              }}</span>
+              <span v-else>
+                {{ t("general.showMore") }}
+              </span>
             </button>
           </div>
         </div>

--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -358,7 +358,7 @@ watch(title, updateTitleScrollable);
       </section>
 
       <!-- Article body -->
-      <section class="py-20">
+      <section class="pt-20 pb-10">
         <div class="page-container">
           <article class="relative w-full">
             <!--
@@ -419,6 +419,7 @@ watch(title, updateTitleScrollable);
           </article>
         </div>
       </section>
+
       <section
         v-if="productionsStatus === 'pending' && linkedProductions.length === 0"
         class="page-container py-10 flex justify-center"
@@ -438,40 +439,44 @@ watch(title, updateTitleScrollable);
 
       <section
         v-else-if="linkedProductions && linkedProductions.length > 0"
-        class="page-container pb-10 border-t border-gray-100 dark:border-[#2e3347]/30 pt-10"
+        class="page-container pb-14 border-t border-gray-100 dark:border-[#2e3347]/30 pt-10"
       >
-        <div class="mb-6">
-          <h2
-            class="font-brand font-black text-2xl lg:text-3xl uppercase tracking-tighter italic text-foreground"
-          >
-            {{ t("stories.relatedProductions", "Gerelateerde voorstellingen") }}
-          </h2>
-        </div>
+        <div class="md:pl-10 w-full">
+          <div class="mb-6">
+            <h2
+              class="font-brand font-black text-2xl lg:text-3xl uppercase tracking-tighter italic text-foreground"
+            >
+              {{
+                t("stories.relatedProductions", "Gerelateerde voorstellingen")
+              }}
+            </h2>
+          </div>
 
-        <div
-          class="flex flex-col gap-4 mb-6 transition-all duration-500 ease-in-out"
-        >
-          <ProductionListViewItem
-            v-for="production in linkedProductions"
-            :key="production.id"
-            :productionView="production"
-            :is-admin="false"
-          />
-        </div>
-
-        <div v-if="hasMore" class="flex justify-center mt-8">
-          <button
-            class="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded font-brand font-black text-[10px] uppercase tracking-widest transition-all duration-300 hover:bg-gray-50 dark:hover:bg-white/5 outline-none"
-            :disabled="productionsStatus === 'pending'"
-            @click="loadMoreProductions"
+          <div
+            class="flex flex-col gap-4 mb-6 transition-all duration-500 ease-in-out"
           >
-            <span v-if="productionsStatus === 'pending'">{{
-              t("general.loading", "Laden...")
-            }}</span>
-            <span v-else>{{
-              t("general.showAll", "Toon alle voorstellingen")
-            }}</span>
-          </button>
+            <ProductionListViewItem
+              v-for="production in linkedProductions"
+              :key="production.id"
+              :productionView="production"
+              :is-admin="false"
+            />
+          </div>
+
+          <div v-if="hasMore" class="flex justify-center mt-8">
+            <button
+              class="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded font-brand font-black text-[10px] uppercase tracking-widest transition-all duration-300 hover:bg-gray-50 dark:hover:bg-white/5 outline-none"
+              :disabled="productionsStatus === 'pending'"
+              @click="loadMoreProductions"
+            >
+              <span v-if="productionsStatus === 'pending'">{{
+                t("general.loading", "Laden...")
+              }}</span>
+              <span v-else>{{
+                t("general.showAll", "Toon alle voorstellingen")
+              }}</span>
+            </button>
+          </div>
         </div>
       </section>
 

--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -115,9 +115,24 @@ const LINKED_PRODUCTIONS_LIMIT = 3;
 const currentLimit = ref(LINKED_PRODUCTIONS_LIMIT);
 const totalLinkedProductions = ref(0);
 
-const hasMore = computed(() => {
-  return linkedProductions.value.length < totalLinkedProductions.value;
+const productionListIsExpanded = computed(() => {
+  return (
+    currentLimit.value >= totalLinkedProductions.value &&
+    totalLinkedProductions.value > LINKED_PRODUCTIONS_LIMIT
+  );
 });
+
+const hasHiddenProductions = computed(() => {
+  return totalLinkedProductions.value > LINKED_PRODUCTIONS_LIMIT;
+});
+
+const toggleProductionsLimit = () => {
+  if (productionListIsExpanded.value) {
+    currentLimit.value = LINKED_PRODUCTIONS_LIMIT;
+  } else {
+    currentLimit.value = totalLinkedProductions.value;
+  }
+};
 
 const loadMoreProductions = () => {
   currentLimit.value = totalLinkedProductions.value;
@@ -439,13 +454,11 @@ watch(title, updateTitleScrollable);
 
       <section
         v-else-if="linkedProductions && linkedProductions.length > 0"
-        class="page-container pb-14 pt-10"
+        class="page-container pb-14 border-t border-gray-200 dark:border-[#2e3347] pt-10"
       >
         <div class="md:pl-10 w-full">
           <div class="mb-6">
-            <h2
-              class="font-brand font-black text-2xl lg:text-3xl uppercase tracking-tighter italic text-foreground"
-            >
+            <h2 class="subtitle">
               {{ t("stories.relatedProductions") }}
             </h2>
           </div>
@@ -461,18 +474,25 @@ watch(title, updateTitleScrollable);
             />
           </div>
 
-          <div v-if="hasMore" class="flex justify-center mt-8">
+          <div v-if="hasHiddenProductions" class="flex justify-center mt-10">
             <button
-              class="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded font-brand font-black text-[10px] uppercase tracking-widest transition-all duration-300 hover:bg-gray-50 dark:hover:bg-white/5 outline-none"
+              @click="toggleProductionsLimit"
               :disabled="productionsStatus === 'pending'"
-              @click="loadMoreProductions"
+              class="text-[11px] font-black uppercase tracking-[2px] text-accent hover:underline outline-none flex items-center gap-2 disabled:opacity-50"
             >
-              <span v-if="productionsStatus === 'pending'">{{
-                t("stories.loading")
-              }}</span>
-              <span v-else>
-                {{ t("general.showMore") }}
-              </span>
+              <template v-if="productionsStatus === 'pending'">
+                {{ t("stories.loading") }}
+              </template>
+              <template v-else-if="!productionListIsExpanded">
+                {{ t("general.showMore") }} ({{
+                  totalLinkedProductions - LINKED_PRODUCTIONS_LIMIT
+                }})
+                <ChevronDown :size="14" stroke-width="3" />
+              </template>
+              <template v-else>
+                {{ t("general.showLess") }}
+                <ChevronUp :size="14" stroke-width="3" />
+              </template>
             </button>
           </div>
         </div>

--- a/frontend/app/pages/stories/[id].vue
+++ b/frontend/app/pages/stories/[id].vue
@@ -456,7 +456,7 @@ watch(title, updateTitleScrollable);
         v-else-if="linkedProductions && linkedProductions.length > 0"
         class="page-container pb-14 border-t border-gray-200 dark:border-[#2e3347] pt-10"
       >
-        <div class="md:pl-10 w-full">
+        <div class="w-full">
           <div class="mb-6">
             <h2 class="subtitle">
               {{ t("stories.relatedProductions") }}
@@ -500,7 +500,7 @@ watch(title, updateTitleScrollable);
 
       <section class="pb-20">
         <div class="page-container">
-          <div class="md:pl-10 w-full">
+          <div class="w-full">
             <!-- Article footer: date + back link -->
             <div
               class="pt-8 border-t flex items-center justify-between border-gray-200 dark:border-[#2e3347]"

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -159,7 +159,12 @@
     "credits": "Credits",
     "doors": "doors",
     "break": "intermission",
-    "gallery": "gallery"
+    "gallery": "gallery",
+    "gallery_nav": {
+      "prev": "Previous image",
+      "next": "Next image",
+      "go_to_slide": "Go to slide {slide}"
+    }
   },
   "general": {
     "back": "Back",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -80,6 +80,7 @@
     "darkMode": "Dark mode",
     "headerDescription": "DISCOVER ARTICLES, INTERVIEWS AND STORIES FROM THE VIERNULVIER ARCHIVE.",
     "sortLabel": "Sort",
+    "relatedProductions": "Related productions",
     "calendar": {
       "toggle": "Date",
       "filtered": "Filtered",

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -81,6 +81,7 @@
     "darkMode": "Donkere modus",
     "headerDescription": "ONTDEK ARTIKELS, INTERVIEWS EN VERHALEN UIT HET VIERNULVIER ARCHIEF.",
     "sortLabel": "Sorteer",
+    "relatedProductions": "Gerelateerde producties",
     "calendar": {
       "toggle": "Datum",
       "filtered": "Gefilterd",

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -160,7 +160,12 @@
     "credits": "Credits",
     "doors": "deuren open",
     "break": "pauze",
-    "gallery": "galerij"
+    "gallery": "galerij",
+    "gallery_nav": {
+      "prev": "Vorige afbeelding",
+      "next": "Volgende afbeelding",
+      "go_to_slide": "Ga naar dia {slide}"
+    }
   },
   "general": {
     "back": "Terug",


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature

* Show the productions that are linked to a blog on it's detail page.

- [x] this PR fixes some existing bugs

* The back button of the blog detail page now takes you to the correct page.
* Gallery (detail production): changed the aspect ratio to 16:9 to prevent image cropping
* new css for subtitles

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code
- [x] external documentation (README, etc.) has been changed

## 🔍 HOW TO TEST

Go to any blog detail page and take a look if you can see any productions. Also try the back button when you navigate to a blog from a production. 

I added a test story to verify the showMore/showLess button that appears when the limit is exceeded. 

## ⚠️ REMAINING ISSUES

@jillvanham will be doing the visual part of displaying the productions on the page.

## ✅ CLOSED ISSUES
- Closes #499
- Closes #501 
