### PR TITLE
Ability to link prints to a production

### DIFF
--- a/backend/src/database/db.production.service.ts
+++ b/backend/src/database/db.production.service.ts
@@ -148,6 +148,18 @@ export class ProductionDatabaseService {
       );
     }
 
+    // Filter to get all productions linked to a gallery that contains a specific print item.
+    if (productionFilters.print_id) {
+      conditions.push(
+        `EXISTS (
+          SELECT 1 FROM production_media_gallery pmg
+          JOIN print_item_media_gallery pimg ON pimg.media_gallery_id = pmg.gallery_id
+          WHERE pmg.production_id = p.id 
+          AND pimg.print_item_id = ${param(productionFilters.print_id)}
+        )`,
+      );
+    }
+
     // Filter by either artist or title. The trgm extension in psql
     if (productionFilters.titelOrArtist) {
       const searchTerm = productionFilters.titelOrArtist;

--- a/common/src/objects/productions.ts
+++ b/common/src/objects/productions.ts
@@ -64,6 +64,8 @@ export const FilterProductionSchema = z.object({
 
   // This will return all productions that are tied to the blog.
   blog_id: z.coerce.number().optional(),
+  // This will return all productions that are tied to a print.
+  print_id: z.coerce.number().optional(),
 
   // Toggle for the backend to treat the request as a suggestion.
   is_suggestion: QueryBoolean.default(false),

--- a/frontend/app/components/PdfThumbnail.vue
+++ b/frontend/app/components/PdfThumbnail.vue
@@ -62,7 +62,7 @@ const openPdf = () => props.src && window.open(props.src, "_blank"); // for open
 </script>
 
 <template>
-  <div class="absolute inset-0 w-full h-full" @click.stop="openPdf">
+  <div class="relative w-full h-full overflow-hidden">
     <div
       v-if="loading"
       class="w-full h-full flex items-center justify-center bg-muted"
@@ -75,7 +75,7 @@ const openPdf = () => props.src && window.open(props.src, "_blank"); // for open
     <canvas
       v-show="!loading && !error"
       ref="canvas"
-      class="w-full h-full object-cover"
+      class="block w-full h-full object-cover"
     />
     <!-- Error fallback -->
     <slot v-if="error" name="fallback" />

--- a/frontend/app/components/admin/productions/MediaForm.vue
+++ b/frontend/app/components/admin/productions/MediaForm.vue
@@ -363,5 +363,30 @@ function toggleCollapse(index: number) {
         </p>
       </div>
     </div>
+
+    <!-- ─── Prints Section ─────────────────────────────────────────────────── -->
+    <div class="mt-8 rounded-xl border border-border bg-card">
+      <div
+        class="flex items-center justify-between border-b border-border px-6 py-4"
+      >
+        <div>
+          <p
+            class="text-[11px] font-black uppercase tracking-widest text-foreground"
+          >
+            {{ t("admin-productions.media.prints") }}
+          </p>
+          <p class="mt-0.5 text-[10px] text-muted-foreground">
+            {{ t("admin-productions.media.printsHint") }}
+          </p>
+        </div>
+      </div>
+
+      <div class="p-6">
+        <AdminProductionsPrintSelector
+          v-model="modelValue.prints"
+          class="w-full"
+        />
+      </div>
+    </div>
   </div>
 </template>

--- a/frontend/app/components/admin/productions/PrintSelector.vue
+++ b/frontend/app/components/admin/productions/PrintSelector.vue
@@ -5,7 +5,7 @@
   Uses a search bar with visual suggestions and displays selected prints as a grid.
 -->
 <script setup lang="ts">
-import { Search, Plus, Trash2 } from "lucide-vue-next";
+import { Search, Trash2, Link, Loader2, X } from "lucide-vue-next";
 import type { PrintItemView } from "@repo/common";
 import { usePrintApi } from "~/composables/media/usePrintApi";
 
@@ -25,15 +25,13 @@ const searchResults = ref<PrintItemView[]>([]);
 const isSearching = ref(false);
 const showDropdown = ref(false);
 
-const inputWrapper = ref<HTMLElement | null>(null);
-const dropdownEl = ref<HTMLElement | null>(null);
-const dropdownStyles = ref<Record<string, string>>({});
+const linkedIds = computed(() => new Set(props.modelValue.map((p) => p.id)));
 
 let searchTimeout: ReturnType<typeof setTimeout> | null = null;
 
 watch(searchQuery, (val) => {
   if (searchTimeout) clearTimeout(searchTimeout);
-  if (val.trim().length === 0) {
+  if (!val.trim()) {
     searchResults.value = [];
     showDropdown.value = false;
     return;
@@ -43,6 +41,7 @@ watch(searchQuery, (val) => {
 
 async function fetchPrints(query: string) {
   isSearching.value = true;
+  showDropdown.value = true;
   try {
     const res = await printApi.getAll({
       printItemFilters: { title: query, is_suggestion: true },
@@ -50,13 +49,7 @@ async function fetchPrints(query: string) {
     });
 
     if (res.data) {
-      // Filter out already selected prints
-      const selectedIds = new Set(props.modelValue.map((p) => p.id));
-      searchResults.value = res.data.objects.filter(
-        (p) => !selectedIds.has(p.id),
-      );
-      showDropdown.value = true;
-      updateDropdownPosition();
+      searchResults.value = res.data.objects ?? [];
     }
   } catch (err) {
     console.error("Failed to fetch prints", err);
@@ -65,6 +58,10 @@ async function fetchPrints(query: string) {
     isSearching.value = false;
   }
 }
+
+const filteredResults = computed(() =>
+  searchResults.value.filter((p) => !linkedIds.value.has(p.id)),
+);
 
 function selectPrint(print: PrintItemView) {
   emit("update:modelValue", [...props.modelValue, print]);
@@ -79,135 +76,113 @@ function removePrint(id: number) {
   );
 }
 
-// ─── Dropdown positioning logic ──────────────────────────────────────────────
-
-function updateDropdownPosition() {
-  if (!inputWrapper.value || !showDropdown.value) {
-    dropdownStyles.value = {};
-    return;
-  }
-  const rect = inputWrapper.value.getBoundingClientRect();
-  dropdownStyles.value = {
-    position: "fixed",
-    top: `${rect.bottom}px`,
-    left: `${rect.left}px`,
-    width: `${rect.width}px`,
-    zIndex: "9999",
-  };
+function clearSearch() {
+  searchQuery.value = "";
 }
+
+// ─── Click outside logic ─────────────────────────────────────────────────────
+const containerRef = ref<HTMLElement | null>(null);
 
 onMounted(() => {
   document.addEventListener("mousedown", onClickOutside);
-  window.addEventListener("resize", updateDropdownPosition);
-  window.addEventListener("scroll", updateDropdownPosition, true);
 });
 
 onUnmounted(() => {
   document.removeEventListener("mousedown", onClickOutside);
-  window.removeEventListener("resize", updateDropdownPosition);
-  window.removeEventListener("scroll", updateDropdownPosition, true);
 });
 
 function onClickOutside(e: MouseEvent) {
-  const target = e.target as Node;
-  if (
-    (inputWrapper.value && inputWrapper.value.contains(target)) ||
-    (dropdownEl.value && dropdownEl.value.contains(target))
-  ) {
-    return;
+  if (containerRef.value && !containerRef.value.contains(e.target as Node)) {
+    showDropdown.value = false;
   }
-  showDropdown.value = false;
 }
-
-watch([showDropdown, searchResults, isSearching, searchQuery], () =>
-  updateDropdownPosition(),
-);
 </script>
 
 <template>
-  <div class="space-y-6">
+  <div class="space-y-6" ref="containerRef">
     <!-- Search Bar -->
-    <div class="relative" ref="inputWrapper">
-      <Search
-        :size="14"
-        class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-      />
-      <input
-        v-model="searchQuery"
-        type="text"
-        class="h-10 w-full rounded-lg border border-border bg-background pl-10 pr-4 text-sm text-foreground transition-colors focus:border-foreground focus:outline-none placeholder:text-muted-foreground/50"
-        :placeholder="t('admin-productions.media.searchPrints')"
-        @focus="searchQuery.length > 0 ? (showDropdown = true) : undefined"
-      />
-
-      <Teleport to="body">
-        <Transition
-          enter-active-class="transition-all duration-100"
-          enter-from-class="opacity-0 -translate-y-1"
-          enter-to-class="opacity-100 translate-y-0"
-          leave-active-class="transition-all duration-75"
-          leave-from-class="opacity-100 translate-y-0"
-          leave-to-class="opacity-0 -translate-y-1"
+    <div class="relative">
+      <div class="relative flex items-center">
+        <Search
+          :size="14"
+          class="pointer-events-none absolute left-3 text-muted-foreground"
+        />
+        <input
+          v-model="searchQuery"
+          type="text"
+          class="h-10 w-full rounded-lg border border-border bg-background pl-10 pr-10 text-sm text-foreground transition-colors focus:border-foreground focus:outline-none placeholder:text-muted-foreground/50"
+          :placeholder="t('admin-productions.media.searchPrints')"
+          @focus="showDropdown = searchQuery.length > 0"
+        />
+        <button
+          v-if="searchQuery"
+          class="absolute right-3 flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+          @click="clearSearch"
         >
-          <div
-            v-if="showDropdown || isSearching"
-            ref="dropdownEl"
-            :style="dropdownStyles"
-            class="overflow-hidden rounded-lg border border-border bg-card shadow-lg"
+          <X :size="14" />
+        </button>
+      </div>
+
+      <!-- Dropdown results -->
+      <div
+        v-if="showDropdown"
+        class="absolute left-0 right-0 z-[100] mt-1 overflow-hidden rounded-lg border border-border bg-card shadow-lg"
+      >
+        <!-- Loading -->
+        <div
+          v-if="isSearching"
+          class="flex items-center gap-2 px-4 py-3 text-[10px] font-black uppercase tracking-widest text-muted-foreground"
+        >
+          <Loader2 :size="12" class="animate-spin" />
+          {{ t("admin-productions.media.searching") }}
+        </div>
+
+        <!-- No Results (either none found or all are already linked) -->
+        <div
+          v-else-if="
+            (searchResults.length === 0 || filteredResults.length === 0) &&
+            !isSearching &&
+            searchQuery
+          "
+          class="px-4 py-3 text-[10px] font-black uppercase tracking-widest text-muted-foreground"
+        >
+          {{ t("admin-productions.media.noPrintsFound") }}
+        </div>
+
+        <!-- Results List -->
+        <ul v-else class="max-h-80 divide-y divide-border overflow-y-auto">
+          <li
+            v-for="print in filteredResults"
+            :key="print.id"
+            class="group flex cursor-pointer items-center gap-3 px-4 py-3 transition-colors hover:bg-muted"
+            @mousedown.prevent="selectPrint(print)"
           >
             <div
-              v-if="isSearching"
-              class="px-4 py-3 text-[10px] font-black uppercase tracking-widest text-muted-foreground"
+              class="relative h-14 w-10 shrink-0 overflow-hidden rounded border border-border transition-colors group-hover:border-foreground/20"
             >
-              {{ t("admin-productions.media.searching") }}
+              <MediaDisplay :src="print" size="fill" class="h-full w-full" />
             </div>
-
-            <template v-else>
-              <div
-                v-if="searchResults.length > 0"
-                class="max-h-80 overflow-y-auto"
+            <div class="min-w-0 flex-1">
+              <p
+                class="truncate text-[11px] font-black uppercase tracking-widest text-foreground"
               >
-                <button
-                  v-for="print in searchResults"
-                  :key="print.id"
-                  class="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-muted"
-                  @mousedown.prevent="selectPrint(print)"
-                >
-                  <div
-                    class="h-12 w-9 shrink-0 overflow-hidden rounded border border-border"
-                  >
-                    <MediaDisplay :src="print" size="fill" />
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <p
-                      class="truncate text-[11px] font-black uppercase tracking-widest text-foreground"
-                    >
-                      {{ print.titel }}
-                    </p>
-                    <p
-                      class="text-[9px] font-black uppercase tracking-widest text-muted-foreground"
-                    >
-                      {{ t(`prints.types.${print.print_type}`) }}
-                    </p>
-                  </div>
-                  <Plus
-                    :size="12"
-                    class="text-muted-foreground"
-                    stroke-width="3"
-                  />
-                </button>
-              </div>
-
-              <div
-                v-else-if="searchQuery.trim().length > 0"
-                class="px-4 py-3 text-[10px] font-black uppercase tracking-widest text-muted-foreground"
+                {{ print.titel }}
+              </p>
+              <p
+                class="mt-0.5 text-[9px] font-black uppercase tracking-widest text-muted-foreground"
               >
-                {{ t("admin-productions.media.noPrintsFound") }}
-              </div>
-            </template>
-          </div>
-        </Transition>
-      </Teleport>
+                {{ t(`prints.types.${print.print_type}`) }}
+              </p>
+            </div>
+            <div
+              class="flex shrink-0 items-center gap-1.5 text-[9px] font-black uppercase tracking-widest text-accent opacity-0 transition-opacity group-hover:opacity-100"
+            >
+              <Link :size="10" stroke-width="3" />
+              {{ t("admin-productions.series.link") }}
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
 
     <!-- Selected Prints Grid -->

--- a/frontend/app/components/admin/productions/PrintSelector.vue
+++ b/frontend/app/components/admin/productions/PrintSelector.vue
@@ -1,0 +1,255 @@
+<!--
+  components/admin/productions/PrintSelector.vue
+
+  UI for searching and selecting Print Items to link to a production.
+  Uses a search bar with visual suggestions and displays selected prints as a grid.
+-->
+<script setup lang="ts">
+import { Search, Plus, Trash2 } from "lucide-vue-next";
+import type { PrintItemView } from "@repo/common";
+import { usePrintApi } from "~/composables/media/usePrintApi";
+
+const props = defineProps<{
+  modelValue: PrintItemView[];
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [PrintItemView[]];
+}>();
+
+const { t, locale } = useI18n();
+const printApi = usePrintApi();
+
+const searchQuery = ref("");
+const searchResults = ref<PrintItemView[]>([]);
+const isSearching = ref(false);
+const showDropdown = ref(false);
+
+const inputWrapper = ref<HTMLElement | null>(null);
+const dropdownEl = ref<HTMLElement | null>(null);
+const dropdownStyles = ref<Record<string, string>>({});
+
+let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+watch(searchQuery, (val) => {
+  if (searchTimeout) clearTimeout(searchTimeout);
+  if (val.trim().length === 0) {
+    searchResults.value = [];
+    showDropdown.value = false;
+    return;
+  }
+  searchTimeout = setTimeout(() => fetchPrints(val.trim()), 300);
+});
+
+async function fetchPrints(query: string) {
+  isSearching.value = true;
+  try {
+    const res = await printApi.getAll({
+      printItemFilters: { title: query, is_suggestion: true },
+      languageFilters: { lang: locale.value as "nl" | "en" },
+    });
+
+    if (res.data) {
+      // Filter out already selected prints
+      const selectedIds = new Set(props.modelValue.map((p) => p.id));
+      searchResults.value = res.data.objects.filter(
+        (p) => !selectedIds.has(p.id),
+      );
+      showDropdown.value = true;
+      updateDropdownPosition();
+    }
+  } catch (err) {
+    console.error("Failed to fetch prints", err);
+    searchResults.value = [];
+  } finally {
+    isSearching.value = false;
+  }
+}
+
+function selectPrint(print: PrintItemView) {
+  emit("update:modelValue", [...props.modelValue, print]);
+  searchQuery.value = "";
+  showDropdown.value = false;
+}
+
+function removePrint(id: number) {
+  emit(
+    "update:modelValue",
+    props.modelValue.filter((p) => p.id !== id),
+  );
+}
+
+// ─── Dropdown positioning logic ──────────────────────────────────────────────
+
+function updateDropdownPosition() {
+  if (!inputWrapper.value || !showDropdown.value) {
+    dropdownStyles.value = {};
+    return;
+  }
+  const rect = inputWrapper.value.getBoundingClientRect();
+  dropdownStyles.value = {
+    position: "fixed",
+    top: `${rect.bottom}px`,
+    left: `${rect.left}px`,
+    width: `${rect.width}px`,
+    zIndex: "9999",
+  };
+}
+
+onMounted(() => {
+  document.addEventListener("mousedown", onClickOutside);
+  window.addEventListener("resize", updateDropdownPosition);
+  window.addEventListener("scroll", updateDropdownPosition, true);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("mousedown", onClickOutside);
+  window.removeEventListener("resize", updateDropdownPosition);
+  window.removeEventListener("scroll", updateDropdownPosition, true);
+});
+
+function onClickOutside(e: MouseEvent) {
+  const target = e.target as Node;
+  if (
+    (inputWrapper.value && inputWrapper.value.contains(target)) ||
+    (dropdownEl.value && dropdownEl.value.contains(target))
+  ) {
+    return;
+  }
+  showDropdown.value = false;
+}
+
+watch([showDropdown, searchResults, isSearching, searchQuery], () =>
+  updateDropdownPosition(),
+);
+</script>
+
+<template>
+  <div class="space-y-6">
+    <!-- Search Bar -->
+    <div class="relative" ref="inputWrapper">
+      <Search
+        :size="14"
+        class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+      />
+      <input
+        v-model="searchQuery"
+        type="text"
+        class="h-10 w-full rounded-lg border border-border bg-background pl-10 pr-4 text-sm text-foreground transition-colors focus:border-foreground focus:outline-none placeholder:text-muted-foreground/50"
+        :placeholder="t('admin-productions.media.searchPrints')"
+        @focus="searchQuery.length > 0 ? (showDropdown = true) : undefined"
+      />
+
+      <Teleport to="body">
+        <Transition
+          enter-active-class="transition-all duration-100"
+          enter-from-class="opacity-0 -translate-y-1"
+          enter-to-class="opacity-100 translate-y-0"
+          leave-active-class="transition-all duration-75"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-1"
+        >
+          <div
+            v-if="showDropdown || isSearching"
+            ref="dropdownEl"
+            :style="dropdownStyles"
+            class="overflow-hidden rounded-lg border border-border bg-card shadow-lg"
+          >
+            <div
+              v-if="isSearching"
+              class="px-4 py-3 text-[10px] font-black uppercase tracking-widest text-muted-foreground"
+            >
+              {{ t("admin-productions.media.searching") }}
+            </div>
+
+            <template v-else>
+              <div
+                v-if="searchResults.length > 0"
+                class="max-h-80 overflow-y-auto"
+              >
+                <button
+                  v-for="print in searchResults"
+                  :key="print.id"
+                  class="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-muted"
+                  @mousedown.prevent="selectPrint(print)"
+                >
+                  <div
+                    class="h-12 w-9 shrink-0 overflow-hidden rounded border border-border"
+                  >
+                    <MediaDisplay :src="print" size="fill" />
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <p
+                      class="truncate text-[11px] font-black uppercase tracking-widest text-foreground"
+                    >
+                      {{ print.titel }}
+                    </p>
+                    <p
+                      class="text-[9px] font-black uppercase tracking-widest text-muted-foreground"
+                    >
+                      {{ t(`prints.types.${print.print_type}`) }}
+                    </p>
+                  </div>
+                  <Plus
+                    :size="12"
+                    class="text-muted-foreground"
+                    stroke-width="3"
+                  />
+                </button>
+              </div>
+
+              <div
+                v-else-if="searchQuery.trim().length > 0"
+                class="px-4 py-3 text-[10px] font-black uppercase tracking-widest text-muted-foreground"
+              >
+                {{ t("admin-productions.media.noPrintsFound") }}
+              </div>
+            </template>
+          </div>
+        </Transition>
+      </Teleport>
+    </div>
+
+    <!-- Selected Prints Grid -->
+    <div
+      v-if="modelValue.length > 0"
+      class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+    >
+      <div
+        v-for="print in modelValue"
+        :key="print.id"
+        class="group relative flex flex-col"
+      >
+        <div
+          class="relative aspect-[3/4] overflow-hidden rounded-lg border border-border transition-colors group-hover:border-accent/40"
+        >
+          <MediaDisplay :src="print" size="fill" />
+
+          <!-- Remove overlay -->
+          <div
+            class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100"
+          >
+            <button
+              class="flex h-8 w-8 items-center justify-center rounded-full bg-action-red-icon text-white transition-transform hover:scale-110"
+              @click="removePrint(print.id)"
+            >
+              <Trash2 :size="14" stroke-width="2.5" />
+            </button>
+          </div>
+        </div>
+        <div class="mt-2">
+          <p
+            class="truncate text-[10px] font-black uppercase tracking-widest text-foreground"
+          >
+            {{ print.titel }}
+          </p>
+          <p
+            class="text-[9px] font-black uppercase tracking-widest text-muted-foreground"
+          >
+            {{ t(`prints.types.${print.print_type}`) }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/app/components/media/Display.vue
+++ b/frontend/app/components/media/Display.vue
@@ -22,7 +22,7 @@
     @error="handleImageError"
     :class="[
       containerClass,
-      props.objectFit ? `object-${props.objectFit}` : '',
+      props.objectFit ? `object-${props.objectFit}` : 'object-cover',
     ]"
   />
   <ThumbnailPlaceholder

--- a/frontend/app/composables/media/useGalleryApi.ts
+++ b/frontend/app/composables/media/useGalleryApi.ts
@@ -135,6 +135,24 @@ export function useGalleryApi() {
     return del(API_ROUTES.galleries.itemLink(galleryId, itemId));
   }
 
+  /**
+   * PUT "/galleries/:galleryId/prints/:itemId"
+   *
+   * Links an print to a gallery.
+   */
+  function linkPrintToGallery(galleryId: number, itemId: number) {
+    return put(API_ROUTES.galleries.printLink(galleryId, itemId), {});
+  }
+
+  /**
+   * DELETE "/galleries/:galleryId/prints/:itemId"
+   *
+   * Unlinks an print from a gallery.
+   */
+  function unlinkPrintFromGallery(galleryId: number, itemId: number) {
+    return del(API_ROUTES.galleries.printLink(galleryId, itemId));
+  }
+
   return {
     getAll,
     getById,
@@ -145,5 +163,7 @@ export function useGalleryApi() {
     getGalleryItems,
     linkItemToGallery,
     unlinkItemFromGallery,
+    linkPrintToGallery,
+    unlinkPrintFromGallery,
   };
 }

--- a/frontend/app/composables/productions/steps/productionMedia.ts
+++ b/frontend/app/composables/productions/steps/productionMedia.ts
@@ -1,5 +1,5 @@
 import type { ProductionFormStep } from "~/types/ProductionFormStep";
-import type { CropName } from "@repo/common";
+import type { CropName, PrintItemView } from "@repo/common";
 import { CROP_NAMES } from "@repo/common";
 
 // ─── Draft types (what the UI works with) ─────────────────────────────────────
@@ -43,6 +43,8 @@ export type MediaItemDraft =
 export type ProductionMediaForm = {
   galleryId: number | null;
   items: MediaItemDraft[];
+  printGalleryId: number | null;
+  prints: PrintItemView[];
 };
 
 // ─── Payload types (what finish works with) ───────────────────────────────────
@@ -82,6 +84,9 @@ export type ProductionMediaPayload = {
   itemsToCreate: ItemCreate[];
   itemsToUpdate: ItemUpdate[];
   itemsToDelete: ItemDelete[];
+  printGalleryId: number | null;
+  printsToLink: number[];
+  printsToUnlink: number[];
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -128,7 +133,12 @@ export function useProductionMedia(): ProductionFormStep<
 > {
   const productionApi = useProductionApi();
 
-  const draft = ref<ProductionMediaForm>({ galleryId: null, items: [] });
+  const draft = ref<ProductionMediaForm>({
+    galleryId: null,
+    items: [],
+    printGalleryId: null,
+    prints: [],
+  });
   const original = ref<ProductionMediaForm | null>(null);
 
   // ─── Initialize ─────────────────────────────────────────────────────────────
@@ -139,63 +149,73 @@ export function useProductionMedia(): ProductionFormStep<
   }): Promise<void> {
     if (context.mode === "create") {
       original.value = null;
-      draft.value = { galleryId: null, items: [] };
+      draft.value = {
+        galleryId: null,
+        items: [],
+        printGalleryId: null,
+        prints: [],
+      };
       return;
     }
 
     if (!context.id) return;
 
     const productionId = Number(context.id);
-    const gallery = await productionApi.getMediaGallery(productionId);
+    const [gallery, printGallery] = await Promise.all([
+      productionApi.getMediaGallery(productionId),
+      productionApi.getPrintsGallery(productionId, "nl"), // Using NL to get PrintItemView
+    ]);
 
-    if (!gallery) {
-      original.value = { galleryId: null, items: [] };
-      draft.value = { galleryId: null, items: [] };
-      return;
-    }
+    const items: MediaItemDraft[] =
+      gallery?.items.map((item) => {
+        const crops = emptyCrops();
 
-    const items: MediaItemDraft[] = gallery.items.map((item) => {
-      const crops = emptyCrops();
-
-      for (const [cropName, crop] of Object.entries(item.crops)) {
-        if (crop) {
-          crops[cropName as CropName] = {
-            type: "existing",
-            id: crop.id,
-            url: crop.url,
-          };
+        for (const [cropName, crop] of Object.entries(item.crops)) {
+          if (crop) {
+            crops[cropName as CropName] = {
+              type: "existing",
+              id: crop.id,
+              url: crop.url,
+            };
+          }
         }
-      }
 
-      const title = item.title as { nl?: string; en?: string } | null;
-      const description = item.description as {
-        nl?: string;
-        en?: string;
-      } | null;
-      const credits = item.credits as { nl?: string; en?: string } | null;
+        const title = item.title as { nl?: string; en?: string } | null;
+        const description = item.description as {
+          nl?: string;
+          en?: string;
+        } | null;
+        const credits = item.credits as { nl?: string; en?: string } | null;
 
-      return {
-        kind: "existing",
-        id: item.id,
-        position: item.position,
-        deleted: false,
-        nl: {
-          title: title?.nl ?? "",
-          description: description?.nl ?? "",
-          credits: credits?.nl ?? "",
-        },
-        en: {
-          title: title?.en ?? "",
-          description: description?.en ?? "",
-          credits: credits?.en ?? "",
-        },
-        crops,
-      };
-    });
+        return {
+          kind: "existing",
+          id: item.id,
+          position: item.position,
+          deleted: false,
+          nl: {
+            title: title?.nl ?? "",
+            description: description?.nl ?? "",
+            credits: credits?.nl ?? "",
+          },
+          en: {
+            title: title?.en ?? "",
+            description: description?.en ?? "",
+            credits: credits?.en ?? "",
+          },
+          crops,
+        };
+      }) ?? [];
 
-    original.value = { galleryId: gallery.id, items };
+    const prints = (printGallery?.items as PrintItemView[]) ?? [];
+
+    original.value = {
+      galleryId: gallery?.id ?? null,
+      items,
+      printGalleryId: printGallery?.id ?? null,
+      prints,
+    };
     draft.value = {
-      galleryId: gallery.id,
+      galleryId: gallery?.id ?? null,
       items: items.map((item) => {
         if (item.kind === "existing" && !item.deleted) {
           return {
@@ -207,6 +227,8 @@ export function useProductionMedia(): ProductionFormStep<
         }
         return { ...item };
       }),
+      printGalleryId: printGallery?.id ?? null,
+      prints: [...prints],
     };
   }
 
@@ -214,7 +236,12 @@ export function useProductionMedia(): ProductionFormStep<
 
   function reset(): void {
     if (!original.value) {
-      draft.value = { galleryId: null, items: [] };
+      draft.value = {
+        galleryId: null,
+        items: [],
+        printGalleryId: null,
+        prints: [],
+      };
       return;
     }
 
@@ -231,6 +258,8 @@ export function useProductionMedia(): ProductionFormStep<
         }
         return { ...item };
       }),
+      printGalleryId: original.value.printGalleryId,
+      prints: [...original.value.prints],
     };
   }
 
@@ -238,11 +267,15 @@ export function useProductionMedia(): ProductionFormStep<
 
   function getChangedFields(): string[] {
     if (!original.value) {
-      return draft.value.items.map((_, i) => `item[${i}]`);
+      return [
+        ...draft.value.items.map((_, i) => `item[${i}]`),
+        ...draft.value.prints.map((p) => `print:${p.id}`),
+      ];
     }
 
     const changes: string[] = [];
 
+    // Media items changes
     for (const item of draft.value.items) {
       if (item.kind === "new") {
         changes.push(`new:${item.position}`);
@@ -275,6 +308,21 @@ export function useProductionMedia(): ProductionFormStep<
         if (crop.type === "empty" && orig.crops[cropName].type === "existing") {
           changes.push(`${item.id}:removed:${cropName}`);
         }
+      }
+    }
+
+    // Prints changes
+    const origPrintIds = new Set(original.value.prints.map((p) => p.id));
+    const draftPrintIds = new Set(draft.value.prints.map((p) => p.id));
+
+    for (const p of draft.value.prints) {
+      if (!origPrintIds.has(p.id)) {
+        changes.push(`print:link:${p.id}`);
+      }
+    }
+    for (const p of original.value.prints) {
+      if (!draftPrintIds.has(p.id)) {
+        changes.push(`print:unlink:${p.id}`);
       }
     }
 
@@ -370,11 +418,24 @@ export function useProductionMedia(): ProductionFormStep<
       });
     }
 
+    const origPrintIds = new Set(original.value?.prints.map((p) => p.id) ?? []);
+    const draftPrintIds = new Set(draft.value.prints.map((p) => p.id));
+
+    const printsToLink = draft.value.prints
+      .filter((p) => !origPrintIds.has(p.id))
+      .map((p) => p.id);
+    const printsToUnlink = (original.value?.prints ?? [])
+      .filter((p) => !draftPrintIds.has(p.id))
+      .map((p) => p.id);
+
     return {
       galleryId: draft.value.galleryId,
       itemsToCreate,
       itemsToUpdate,
       itemsToDelete,
+      printGalleryId: draft.value.printGalleryId,
+      printsToLink,
+      printsToUnlink,
     };
   }
 

--- a/frontend/app/composables/productions/useProductionFormPage.ts
+++ b/frontend/app/composables/productions/useProductionFormPage.ts
@@ -20,6 +20,7 @@ import { useStorageApi } from "~/composables/media/useStorageApi";
 import { useProductionSeries } from "~/composables/productions/steps/productionSeries";
 import { useSeriesApi } from "~/composables/useSeriesApi";
 import type { LocalizedInput } from "~/composables/productions/steps/productionSeries";
+import { ROUTES } from "~/utils/routes";
 
 export type ProductionFormMode = "create" | "edit";
 
@@ -81,6 +82,21 @@ export function useProductionFormPage(mode: ProductionFormMode) {
       type: "default",
     });
     if (!res.data) throw new Error("Failed to create gallery");
+    await productionApi.linkMedia(productionId, res.data.id);
+    return res.data.id;
+  }
+
+  async function ensurePrintGallery(
+    productionId: number,
+    existingGalleryId: number | null,
+  ): Promise<number> {
+    if (existingGalleryId !== null) return existingGalleryId;
+
+    const res = await galleryApi.create({
+      name: `production-${productionId}-prints`,
+      type: "prints",
+    });
+    if (!res.data) throw new Error("Failed to create print gallery");
     await productionApi.linkMedia(productionId, res.data.id);
     return res.data.id;
   }
@@ -285,6 +301,13 @@ export function useProductionFormPage(mode: ProductionFormMode) {
         await persistItemCreate(item, galleryId, productionId);
       }
     }
+
+    if (mediaPayload.printsToLink.length > 0) {
+      const printGalleryId = await ensurePrintGallery(productionId, null);
+      for (const printId of mediaPayload.printsToLink) {
+        await galleryApi.linkPrintToGallery(printGalleryId, printId);
+      }
+    }
   }
 
   async function handleMediaEdit(
@@ -296,20 +319,41 @@ export function useProductionFormPage(mode: ProductionFormMode) {
       mediaPayload.itemsToUpdate.length > 0 ||
       mediaPayload.itemsToDelete.length > 0;
 
-    if (!hasMediaChanges) return;
+    if (hasMediaChanges) {
+      // Deletions first
+      for (const item of mediaPayload.itemsToDelete) {
+        await persistItemDelete(item);
+      }
 
-    // Deletions first
-    for (const item of mediaPayload.itemsToDelete) {
-      await persistItemDelete(item);
+      const galleryId = await ensureGallery(
+        productionId,
+        mediaPayload.galleryId,
+      );
+
+      for (const item of mediaPayload.itemsToCreate) {
+        await persistItemCreate(item, galleryId, productionId);
+      }
+      for (const item of mediaPayload.itemsToUpdate) {
+        await persistItemUpdate(item, productionId);
+      }
     }
 
-    const galleryId = await ensureGallery(productionId, mediaPayload.galleryId);
+    const hasPrintChanges =
+      mediaPayload.printsToLink.length > 0 ||
+      mediaPayload.printsToUnlink.length > 0;
 
-    for (const item of mediaPayload.itemsToCreate) {
-      await persistItemCreate(item, galleryId, productionId);
-    }
-    for (const item of mediaPayload.itemsToUpdate) {
-      await persistItemUpdate(item, productionId);
+    if (hasPrintChanges) {
+      const printGalleryId = await ensurePrintGallery(
+        productionId,
+        mediaPayload.printGalleryId,
+      );
+
+      for (const printId of mediaPayload.printsToLink) {
+        await galleryApi.linkPrintToGallery(printGalleryId, printId);
+      }
+      for (const printId of mediaPayload.printsToUnlink) {
+        await galleryApi.unlinkPrintFromGallery(printGalleryId, printId);
+      }
     }
   }
 

--- a/frontend/app/utils/apiRoutes.ts
+++ b/frontend/app/utils/apiRoutes.ts
@@ -72,6 +72,8 @@ export const API_ROUTES = {
     items: (galleryId: number) => `/media/galleries/${galleryId}/items`,
     itemLink: (galleryId: number, itemId: number) =>
       `/media/galleries/${galleryId}/items/${itemId}`,
+    printLink: (galleryId: number, itemId: number) =>
+      `/media/galleries/${galleryId}/prints/${itemId}`,
   },
   items: {
     base: "/media/items",

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -500,7 +500,12 @@
       "carouselHint": "Used as a collection of additional photos",
       "carouselItem": "Carousel image",
       "noCarousel": "No carousel images added yet",
-      "fallbackHint": "Falls back to NL"
+      "fallbackHint": "Falls back to NL",
+      "prints": "Prints",
+      "printsHint": "Link existing print items to this production",
+      "searchPrints": "Search prints by title...",
+      "noPrintsFound": "No prints found",
+      "searching": "Searching..."
     },
     "tags": {
       "available": "Available tags",

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -502,7 +502,12 @@
       "carouselHint": "Wordt gebruikt als verzameling van extra foto’s.",
       "carouselItem": "Carrouselafbeeldingen",
       "noCarousel": "Nog geen Carrouselafbeeldingen toegevoegd",
-      "fallbackHint": "Valt terug op NL"
+      "fallbackHint": "Valt terug op NL",
+      "prints": "Drukwerk",
+      "printsHint": "Koppel bestaand drukwerk aan deze productie",
+      "searchPrints": "Zoek drukwerk op titel...",
+      "noPrintsFound": "Geen drukwerk gevonden",
+      "searching": "Zoeken..."
     },
     "tags": {
       "available": "Beschikbare tags",


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature
* The admin page for productions now lets you link prints to a production.
* There is an extra `print_id` field in the `FilterProduction` object that lets you fetch the list of productions that has a print.

## 🛠️ TESTING
- [x] there is enough test coverage for this code
- [x] all tests succeed

## 📝 DOCUMENTATION
- [x] there is enough documentation written for this code
- [x] external documentation (README, etc.) has been changed

## 🔍 HOW TO TEST

You can navigate to the production admin page and then create or edit one. Then navigate to the `media` step and scroll all the way to the bottom to select prints.

## 📸 SCREENSHOTS (if necessary):

<img width="1041" height="464" alt="image" src="https://github.com/user-attachments/assets/e81deb7f-0402-46d6-acb5-12cb526eac50" />

## ✅ CLOSED ISSUES
- Closes #515 
