### PR TITLE
Production prints, new description component & header bugfix

### DIFF
--- a/frontend/app/components/AppHeader.vue
+++ b/frontend/app/components/AppHeader.vue
@@ -211,7 +211,7 @@ const adminNavItems = [
         </nav>
 
         <button
-          class="lg:hidden outline-none transition-colors text-[var(--foreground)]"
+          class="outline-none transition-colors text-[var(--foreground)]"
           :class="showAdminInterface ? 'lg:hidden' : 'xl:hidden'"
           @click.stop="toggleMenu"
         >

--- a/frontend/app/components/ThemeToggle.vue
+++ b/frontend/app/components/ThemeToggle.vue
@@ -22,6 +22,11 @@ const isDark = ref(false);
 const applyTheme = (dark: boolean) => {
   document.documentElement.classList.toggle("dark", dark);
   localStorage.setItem("theme", dark ? "dark" : "light");
+
+  // signal theme changed
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event("theme-changed"));
+  }
 };
 
 const toggleDark = () => {

--- a/frontend/app/components/production/ProductionDescription.vue
+++ b/frontend/app/components/production/ProductionDescription.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount, nextTick } from "vue";
+
+interface Props {
+  htmlContent: string;
+  variant?: "default" | "boxed";
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: "default",
+});
+
+const { t } = useI18n();
+
+const isExpanded = ref(false);
+const showReadMoreButton = ref(false);
+const descriptionRef = ref<HTMLElement | null>(null);
+
+const checkOverflow = () => {
+  if (descriptionRef.value) {
+    showReadMoreButton.value =
+      descriptionRef.value.scrollHeight > descriptionRef.value.clientHeight;
+  }
+};
+
+let observer: ResizeObserver | null = null;
+
+onMounted(async () => {
+  await nextTick();
+  observer = new ResizeObserver(() => checkOverflow());
+
+  if (descriptionRef.value) {
+    observer.observe(descriptionRef.value);
+  }
+});
+
+onBeforeUnmount(() => {
+  observer?.disconnect();
+});
+</script>
+
+<template>
+  <div class="w-full">
+    <div v-if="variant === 'default'">
+      <div
+        ref="descriptionRef"
+        :class="[
+          isExpanded ? 'line-clamp-none' : 'line-clamp-[6] md:line-clamp-[8]',
+          showReadMoreButton && !isExpanded ? 'should-fade' : '',
+        ]"
+        class="description-content text-lg lg:text-xl leading-relaxed opacity-80 font-brand text-gray-800 dark:text-gray-200 transition-all duration-500"
+        v-html="htmlContent"
+      ></div>
+
+      <button
+        v-if="showReadMoreButton || isExpanded"
+        class="mt-6 mb-4 text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
+        @click="isExpanded = !isExpanded"
+      >
+        {{ isExpanded ? t("general.readLess") : t("general.readMore") }}
+      </button>
+    </div>
+
+    <div v-else-if="variant === 'boxed'">
+      <div
+        ref="descriptionRef"
+        :class="[
+          isExpanded ? 'line-clamp-none' : 'line-clamp-[6]',
+          showReadMoreButton && !isExpanded ? 'should-fade' : '',
+        ]"
+        class="description-content p-8 bg-gray-100 dark:bg-white/5 border-l-2 border-gray-200 dark:border-gray-700 italic opacity-80 text-lg lg:text-xl rounded-2xl transition-all duration-500"
+        v-html="htmlContent"
+      ></div>
+
+      <button
+        v-if="showReadMoreButton || isExpanded"
+        class="mt-4 ml-8 text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
+        @click="isExpanded = !isExpanded"
+      >
+        {{ isExpanded ? t("general.readLess") : t("general.readMore") }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.description-content :deep(a) {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.description-content :deep(a:hover) {
+  opacity: 0.7;
+}
+
+.should-fade {
+  mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+}
+
+.line-clamp-none {
+  mask-image: none !important;
+  -webkit-mask-image: none !important;
+}
+</style>

--- a/frontend/app/components/production/ProductionDescription.vue
+++ b/frontend/app/components/production/ProductionDescription.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, nextTick, watch } from "vue";
+import {
+  ref,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+  watch,
+  computed,
+} from "vue";
 
 interface Props {
   htmlContent: string;
@@ -16,6 +23,17 @@ const isExpanded = ref(false);
 const showReadMoreButton = ref(false);
 const descriptionRef = ref<HTMLElement | null>(null);
 
+const variantClasses = computed(() => {
+  if (props.variant === "boxed") {
+    return "p-8 bg-muted border-l-2 border-gray-200 dark:border-gray-700 italic rounded-2xl";
+  }
+  return "";
+});
+
+const buttonClasses = computed(() => {
+  return props.variant === "boxed" ? "mt-4 ml-8" : "mt-6 mb-4";
+});
+
 const checkOverflow = () => {
   if (descriptionRef.value) {
     showReadMoreButton.value =
@@ -28,10 +46,7 @@ let observer: ResizeObserver | null = null;
 onMounted(async () => {
   await nextTick();
   observer = new ResizeObserver(() => checkOverflow());
-
-  if (descriptionRef.value) {
-    observer.observe(descriptionRef.value);
-  }
+  if (descriptionRef.value) observer.observe(descriptionRef.value);
 });
 
 watch(
@@ -43,52 +58,30 @@ watch(
   { immediate: true },
 );
 
-onBeforeUnmount(() => {
-  observer?.disconnect();
-});
+onBeforeUnmount(() => observer?.disconnect());
 </script>
 
 <template>
   <div class="w-full">
-    <div v-if="variant === 'default'">
-      <div
-        ref="descriptionRef"
-        :class="[
-          isExpanded ? 'line-clamp-none' : 'line-clamp-[6] md:line-clamp-[8]',
-          showReadMoreButton && !isExpanded ? 'should-fade' : '',
-        ]"
-        class="description-content text-lg lg:text-xl leading-relaxed opacity-80 font-brand text-gray-800 dark:text-gray-200 transition-all duration-500"
-        v-html="htmlContent"
-      ></div>
+    <div
+      ref="descriptionRef"
+      :class="[
+        variantClasses,
+        isExpanded ? 'line-clamp-none' : 'line-clamp-[6] md:line-clamp-[8]',
+        showReadMoreButton && !isExpanded ? 'should-fade' : '',
+      ]"
+      class="description-content text-lg lg:text-xl leading-relaxed text-gray-800 dark:text-gray-200 opacity-80 font-brand transition-all duration-500"
+      v-html="htmlContent"
+    ></div>
 
-      <button
-        v-if="showReadMoreButton || isExpanded"
-        class="mt-6 mb-4 text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
-        @click="isExpanded = !isExpanded"
-      >
-        {{ isExpanded ? t("general.readLess") : t("general.readMore") }}
-      </button>
-    </div>
-
-    <div v-else-if="variant === 'boxed'">
-      <div
-        ref="descriptionRef"
-        :class="[
-          isExpanded ? 'line-clamp-none' : 'line-clamp-[6] md:line-clamp-[8]',
-          showReadMoreButton && !isExpanded ? 'should-fade' : '',
-        ]"
-        class="description-content p-8 bg-gray-100 dark:bg-white/5 border-l-2 border-gray-200 dark:border-gray-700 italic opacity-80 text-lg lg:text-xl rounded-2xl transition-all duration-500"
-        v-html="htmlContent"
-      ></div>
-
-      <button
-        v-if="showReadMoreButton || isExpanded"
-        class="mt-4 ml-8 text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
-        @click="isExpanded = !isExpanded"
-      >
-        {{ isExpanded ? t("general.readLess") : t("general.readMore") }}
-      </button>
-    </div>
+    <button
+      v-if="showReadMoreButton || isExpanded"
+      :class="buttonClasses"
+      class="text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
+      @click="isExpanded = !isExpanded"
+    >
+      {{ isExpanded ? t("general.readLess") : t("general.readMore") }}
+    </button>
   </div>
 </template>
 

--- a/frontend/app/components/production/ProductionDescription.vue
+++ b/frontend/app/components/production/ProductionDescription.vue
@@ -22,6 +22,7 @@ const { t } = useI18n();
 const isExpanded = ref(false);
 const showReadMoreButton = ref(false);
 const descriptionRef = ref<HTMLElement | null>(null);
+const themeKey = ref(0);
 
 const variantClasses = computed(() => {
   if (props.variant === "boxed") {
@@ -41,12 +42,23 @@ const checkOverflow = () => {
   }
 };
 
-let observer: ResizeObserver | null = null;
+const handleThemeChange = async () => {
+  themeKey.value++;
+  await nextTick();
+  checkOverflow();
+};
+
+let resizeObserver: ResizeObserver | null = null;
 
 onMounted(async () => {
   await nextTick();
-  observer = new ResizeObserver(() => checkOverflow());
-  if (descriptionRef.value) observer.observe(descriptionRef.value);
+
+  // Observe screen size
+  resizeObserver = new ResizeObserver(() => checkOverflow());
+  if (descriptionRef.value) resizeObserver.observe(descriptionRef.value);
+
+  // Listen to signal theme toggle
+  window.addEventListener("theme-changed", handleThemeChange);
 });
 
 watch(
@@ -58,12 +70,16 @@ watch(
   { immediate: true },
 );
 
-onBeforeUnmount(() => observer?.disconnect());
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  window.removeEventListener("theme-changed", handleThemeChange);
+});
 </script>
 
 <template>
   <div class="w-full">
     <div
+      :key="themeKey"
       ref="descriptionRef"
       :class="[
         variantClasses,

--- a/frontend/app/components/production/ProductionDescription.vue
+++ b/frontend/app/components/production/ProductionDescription.vue
@@ -42,22 +42,36 @@ const checkOverflow = () => {
   }
 };
 
-const handleThemeChange = async () => {
-  themeKey.value++;
-  await nextTick();
-  checkOverflow();
+let resizeObserver: ResizeObserver | null = null;
+
+// safely (re)attach the observer
+const startObserving = () => {
+  if (descriptionRef.value && resizeObserver) {
+    resizeObserver.observe(descriptionRef.value);
+  }
 };
 
-let resizeObserver: ResizeObserver | null = null;
+const handleThemeChange = async () => {
+  // Disconnect from old DOM node before it gets destroyed
+  resizeObserver?.disconnect();
+
+  themeKey.value++;
+
+  // Wait until Vue rendered new DOM node with updated key
+  await nextTick();
+
+  checkOverflow();
+  startObserving(); // Attach observer to new DOM node
+};
 
 onMounted(async () => {
   await nextTick();
 
-  // Observe screen size
+  // Initialize observer
   resizeObserver = new ResizeObserver(() => checkOverflow());
-  if (descriptionRef.value) resizeObserver.observe(descriptionRef.value);
+  startObserving();
 
-  // Listen to signal theme toggle
+  // Listen to theme toggle signal
   window.addEventListener("theme-changed", handleThemeChange);
 });
 

--- a/frontend/app/components/production/ProductionDescription.vue
+++ b/frontend/app/components/production/ProductionDescription.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, nextTick } from "vue";
+import { ref, onMounted, onBeforeUnmount, nextTick, watch } from "vue";
 
 interface Props {
   htmlContent: string;
@@ -34,6 +34,15 @@ onMounted(async () => {
   }
 });
 
+watch(
+  () => props.htmlContent,
+  async () => {
+    await nextTick();
+    checkOverflow();
+  },
+  { immediate: true },
+);
+
 onBeforeUnmount(() => {
   observer?.disconnect();
 });
@@ -65,7 +74,7 @@ onBeforeUnmount(() => {
       <div
         ref="descriptionRef"
         :class="[
-          isExpanded ? 'line-clamp-none' : 'line-clamp-[6]',
+          isExpanded ? 'line-clamp-none' : 'line-clamp-[6] md:line-clamp-[8]',
           showReadMoreButton && !isExpanded ? 'should-fade' : '',
         ]"
         class="description-content p-8 bg-gray-100 dark:bg-white/5 border-l-2 border-gray-200 dark:border-gray-700 italic opacity-80 text-lg lg:text-xl rounded-2xl transition-all duration-500"
@@ -84,6 +93,15 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
+.description-content :deep(p) {
+  margin-bottom: 1.25rem;
+}
+
+.description-content :deep(p:last-child) {
+  margin-bottom: 0;
+}
+
+/* Links in description */
 .description-content :deep(a) {
   text-decoration: underline;
   text-underline-offset: 4px;

--- a/frontend/app/components/production/ProductionPrints.vue
+++ b/frontend/app/components/production/ProductionPrints.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+/**
+ * Component to show prints on production detail page (for specific productionId)
+ */
+
+import { computed } from "vue";
+import type { PrintItemView } from "@repo/common";
+
+interface Props {
+  productionId: number;
+}
+
+const props = defineProps<Props>();
+
+const { t, locale } = useI18n();
+const { getPrintsGallery } = useProductionApi();
+
+/**
+ * Get the prints gallery for this production
+ */
+const { data: galleryData, status } = useAsyncData(
+  `prod-prints-${props.productionId}-${locale.value}`,
+  async () => {
+    if (!props.productionId) return null;
+    const res = await getPrintsGallery(props.productionId, locale.value as any);
+    return (res as any)?.data ?? res;
+  },
+  { watch: [() => props.productionId, locale] },
+);
+
+/**
+ * Sort prints
+ */
+const allPrints = computed<PrintItemView[]>(() => {
+  if (!galleryData.value || !galleryData.value.items) return [];
+
+  return [...galleryData.value.items].sort((a, b) => {
+    const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return dateB - dateA;
+  });
+});
+
+const hasPrints = computed(() => allPrints.value.length > 0);
+</script>
+
+<template>
+  <div v-if="status === 'success' && hasPrints" class="w-full">
+    <h2 class="subtitle mb-6">
+      {{ t("production.prints") }}
+    </h2>
+
+    <div
+      class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 items-start"
+    >
+      <PrintsFileGridItem
+        v-for="file in allPrints"
+        :key="file.id"
+        :file="file"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/frontend/app/components/production/ProductionPrints.vue
+++ b/frontend/app/components/production/ProductionPrints.vue
@@ -4,7 +4,7 @@
  */
 
 import { computed } from "vue";
-import type { PrintItemView } from "@repo/common";
+import type { PrintItemView, Language } from "@repo/common";
 
 interface Props {
   productionId: number;
@@ -22,7 +22,10 @@ const { data: galleryData, status } = useAsyncData(
   `prod-prints-${props.productionId}-${locale.value}`,
   async () => {
     if (!props.productionId) return null;
-    const res = await getPrintsGallery(props.productionId, locale.value as any);
+    const res = await getPrintsGallery(
+      props.productionId,
+      locale.value as Language,
+    );
     return (res as any)?.data ?? res;
   },
   { watch: [() => props.productionId, locale] },

--- a/frontend/app/components/production/ProductionPrints.vue
+++ b/frontend/app/components/production/ProductionPrints.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 /**
- * Component to show prints on production detail page (for specific productionId)
+ * Component to show related prints on production detail page
  */
 
 import { computed } from "vue";

--- a/frontend/app/pages/productions/[id].vue
+++ b/frontend/app/pages/productions/[id].vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed } from "vue";
 import { ChevronLeft } from "lucide-vue-next";
 import type { ProductionView, TagView } from "@repo/common";
 import { cleanText } from "~/utils/formatters";
@@ -170,38 +170,6 @@ const isValid = (val: any) => {
 const fullDescription = computed(
   () => cleanText(production.value?.description1) || "",
 );
-const isExpanded = ref(false);
-const showReadMoreButton = ref(false);
-const descriptionRef = ref<HTMLElement | null>(null);
-
-const isExpanded2 = ref(false);
-const showReadMoreButton2 = ref(false);
-const description2Ref = ref<HTMLElement | null>(null);
-
-const checkOverflow = () => {
-  if (descriptionRef.value) {
-    showReadMoreButton.value =
-      descriptionRef.value.scrollHeight > descriptionRef.value.clientHeight;
-  }
-  if (description2Ref.value) {
-    showReadMoreButton2.value =
-      description2Ref.value.scrollHeight > description2Ref.value.clientHeight;
-  }
-};
-
-let observer: ResizeObserver | null = null;
-
-onMounted(async () => {
-  await nextTick();
-  observer = new ResizeObserver(() => checkOverflow());
-
-  if (descriptionRef.value) observer.observe(descriptionRef.value);
-  if (description2Ref.value) observer.observe(description2Ref.value);
-});
-
-onBeforeUnmount(() => {
-  observer?.disconnect();
-});
 </script>
 
 <template>
@@ -209,6 +177,7 @@ onBeforeUnmount(() => {
     v-if="production"
     class="min-h-screen bg-white dark:bg-[#1e2230] text-gray-900 dark:text-gray-100"
   >
+    <!-- Hero -->
     <section
       :class="{ 'image-overlay text-white': headerCrop }"
       class="relative h-[400px] lg:h-[500px] w-full flex items-end overflow-hidden bg-muted"
@@ -294,25 +263,7 @@ onBeforeUnmount(() => {
             </p>
           </div>
 
-          <div
-            ref="descriptionRef"
-            :class="[
-              isExpanded
-                ? 'line-clamp-none'
-                : 'line-clamp-[6] md:line-clamp-[8]',
-              showReadMoreButton && !isExpanded ? 'should-fade' : '',
-            ]"
-            class="description-content text-lg lg:text-xl leading-relaxed opacity-80 font-brand text-gray-800 dark:text-gray-200 transition-all duration-500"
-            v-html="fullDescription"
-          ></div>
-
-          <button
-            v-if="showReadMoreButton || isExpanded"
-            class="mt-6 mb-4 text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
-            @click="isExpanded = !isExpanded"
-          >
-            {{ isExpanded ? t("general.readLess") : t("general.readMore") }}
-          </button>
+          <ProductionDescription :html-content="fullDescription" />
         </div>
 
         <div class="mt-12 mb-16">
@@ -328,25 +279,12 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <div v-if="isValid(production.description2)" class="mb-16">
-          <div
-            ref="description2Ref"
-            :class="[
-              isExpanded2 ? 'line-clamp-none' : 'line-clamp-[6]',
-              showReadMoreButton2 && !isExpanded2 ? 'should-fade' : '',
-            ]"
-            class="description-content p-8 bg-gray-100 dark:bg-white/5 border-l-2 border-gray-200 dark:border-gray-700 italic opacity-80 text-lg lg:text-xl rounded-2xl transition-all duration-500"
-            v-html="cleanText(production.description2)"
-          ></div>
-
-          <button
-            v-if="showReadMoreButton2 || isExpanded2"
-            class="mt-4 ml-8 text-[11px] font-black uppercase tracking-[2px] text-[var(--accent)] hover:underline outline-none"
-            @click="isExpanded2 = !isExpanded2"
-          >
-            {{ isExpanded2 ? t("general.readLess") : t("general.readMore") }}
-          </button>
-        </div>
+        <ProductionDescription
+          v-if="isValid(production.description2)"
+          :html-content="cleanText(production.description2)"
+          variant="boxed"
+          class="mb-16"
+        />
 
         <div v-if="stories && stories.length > 0" class="my-16">
           <h2 class="subtitle mb-4">
@@ -389,26 +327,6 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
-/* links in description */
-.description-content :deep(a) {
-  text-decoration: underline;
-  text-underline-offset: 4px;
-}
-
-.description-content :deep(a:hover) {
-  opacity: 0.7;
-}
-
-.should-fade {
-  mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
-  -webkit-mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
-}
-
-.line-clamp-none {
-  mask-image: none !important;
-  -webkit-mask-image: none !important;
-}
-
 .image-overlay::after {
   content: "";
   position: absolute;

--- a/frontend/app/pages/productions/[id].vue
+++ b/frontend/app/pages/productions/[id].vue
@@ -355,6 +355,8 @@ onBeforeUnmount(() => {
           <ProductionStoryListView :stories="stories" />
         </div>
 
+        <ProductionPrints v-if="productionId" :production-id="productionId" />
+
         <div v-if="carouselImages && carouselImages.length > 0" class="my-16">
           <h2 class="subtitle mb-4">
             {{ t("production.gallery") }}
@@ -367,7 +369,7 @@ onBeforeUnmount(() => {
 
         <div
           v-if="isValid(production.credits)"
-          class="pt-12 flex flex-col items-center"
+          class="flex flex-col items-center"
         >
           <div class="max-w-2xl text-center">
             <h4

--- a/frontend/app/pages/productions/[id].vue
+++ b/frontend/app/pages/productions/[id].vue
@@ -166,10 +166,6 @@ const isValid = (val: any) => {
   const s = String(val).trim().toUpperCase();
   return s !== "" && s !== "N/A" && s !== "UNDEFINED";
 };
-
-const fullDescription = computed(
-  () => cleanText(production.value?.description1) || "",
-);
 </script>
 
 <template>
@@ -263,7 +259,9 @@ const fullDescription = computed(
             </p>
           </div>
 
-          <ProductionDescription :html-content="fullDescription" />
+          <ProductionDescription
+            :html-content="cleanText(production.description1)"
+          />
         </div>
 
         <div class="mt-12 mb-16">

--- a/frontend/app/utils/formatters.ts
+++ b/frontend/app/utils/formatters.ts
@@ -221,9 +221,16 @@ export function stripHtml(html: string): string {
  */
 export const cleanText = (text: string | null | undefined) => {
   if (!text) return "";
-  return text
-    .replace(/\\/g, "")
-    .trim()
-    .replace(/(\r?\n){2,}/g, "\n\n")
-    .replace(/\n/g, "<br />");
+
+  return (
+    text
+      .replace(/\\/g, "")
+      // 1. Convert multiple newlines into clean double newlines
+      .replace(/(\r?\n){2,}/g, "\n\n")
+      // 2. Convert remaining single newlines to HTML breaks
+      .replace(/\n/g, "<br />")
+      // 3. Strip all trailing empty paragraphs, breaks, and spaces
+      .replace(/(<p>(&nbsp;|\s)*<\/p>|<br\s*\/?>|\s)+$/, "")
+      .trim()
+  );
 };

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -162,6 +162,7 @@
     "credits": "Credits",
     "doors": "doors",
     "break": "intermission",
+    "prints": "prints",
     "gallery": "gallery",
     "gallery_nav": {
       "prev": "Previous image",

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -163,6 +163,7 @@
     "credits": "Credits",
     "doors": "deuren open",
     "break": "pauze",
+    "prints": "drukwerk",
     "gallery": "galerij",
     "gallery_nav": {
       "prev": "Vorige afbeelding",

--- a/frontend/tests/components/event/EventListView.spec.ts
+++ b/frontend/tests/components/event/EventListView.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mount, VueWrapper } from "@vue/test-utils";
 import { createI18n } from "vue-i18n";
 import EventListView from "../../../app/components/event/EventListView.vue";
@@ -10,6 +10,7 @@ vi.mock("#app", async (importOriginal) => {
 
   return {
     ...actual,
+    navigateTo: vi.fn(), // Mocking navigateTo here as well for Nuxt auto-imports
   };
 });
 
@@ -76,6 +77,9 @@ describe("EventListView", () => {
   let wrapper: VueWrapper<InstanceType<typeof EventListView>>;
 
   beforeEach(() => {
+    // Stub global navigateTo to prevent 'history is not defined' Vue Router errors
+    vi.stubGlobal("navigateTo", vi.fn());
+
     wrapper = mount(EventListView, {
       global: {
         plugins: [i18n],
@@ -84,6 +88,11 @@ describe("EventListView", () => {
         events,
       },
     });
+  });
+
+  afterEach(() => {
+    // Clean up global stubs to prevent test leakage
+    vi.unstubAllGlobals();
   });
 
   it("renders the event cards", () => {


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [x] this PR implements a new feature
* Added Prints section on the production detail page
* Created a new reusable `ProductionDescription` component (used for description1 and description2)

- [x] this PR fixes some existing bugs
* Fixed an issue where the header menu button was hidden on small screens when no navigation links were present.

## 🔍 HOW TO TEST
Check multiple production detail pages to verify the new description and prints layout (check production 14595). Also, test the header visibility across multiple screen sizes.