### PR TITLE
Productions on prints page

### DIFF
--- a/frontend/app/components/prints/FileGridItem.vue
+++ b/frontend/app/components/prints/FileGridItem.vue
@@ -9,18 +9,46 @@
  *    :file="file"
  * />
  */
-import type { PrintItemView } from "@repo/common";
+import { ref, watch, onUnmounted } from "vue";
+import type { PrintItemView, ProductionView } from "@repo/common";
 import { Info, X } from "lucide-vue-next";
+import { useProductionApi } from "~/composables/useProductionApi"; // Uses your existing production composable
+import { ROUTES } from "~/utils/routes";
 
 interface Props {
   file: PrintItemView;
 }
-defineProps<Props>();
+const props = defineProps<Props>();
 const { t, locale } = useI18n();
+const { getAll: getProductions } = useProductionApi();
 
 const fileLabel = "text-[11px] font-bold uppercase truncate";
 const openFile = (src: string) => window.open(src, "_blank"); // for opening the PDF in a new browser tab
 const showInfo = ref(false); // if the info (description) section is opened or if not
+
+const linkedProductions = ref<ProductionView[]>([]);
+const isLoadingProductions = ref(false);
+
+const loadLinkedProductions = async () => {
+  if (!props.file?.id) return;
+
+  isLoadingProductions.value = true;
+  try {
+    const resp = await getProductions({
+      productionFilters: { print_id: props.file.id },
+      paginationFilters: { page: 0, limit: 50, descending: false }, // Request a safe layout limit
+      languageFilters: { lang: locale.value },
+    });
+
+    if (resp.data && Array.isArray(resp.data.objects)) {
+      linkedProductions.value = resp.data.objects as ProductionView[];
+    }
+  } catch (err) {
+    console.error("Error loading linked productions for print item:", err);
+  } finally {
+    isLoadingProductions.value = false;
+  }
+};
 
 watch(showInfo, (val) => {
   // Prevents scrolling when description is opened
@@ -28,6 +56,9 @@ watch(showInfo, (val) => {
   if (val) {
     document.body.style.paddingRight = `${window.innerWidth - document.documentElement.clientWidth}px`;
     document.body.style.overflow = "hidden";
+
+    // Lazy load the productions
+    loadLinkedProductions();
   } else {
     document.body.style.paddingRight = "";
     document.body.style.overflow = "";
@@ -54,7 +85,7 @@ onUnmounted(() => {
       <button
         v-if="file.description && file.description != ''"
         @click.stop="showInfo = true"
-        class="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 hover:bg-black/70 flex items-center justify-center transition-colors"
+        class="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 hover:bg-black/70 flex items-center justify-center transition-colors z-10"
       >
         <Info class="w-3.5 h-3.5 text-white" />
       </button>
@@ -84,12 +115,59 @@ onUnmounted(() => {
               >
                 {{ file.titel }}
               </p>
-              <!-- Description -->
-              <p
-                class="text-sm leading-relaxed text-muted-foreground overflow-y-auto break-words"
-              >
-                {{ file.description }}
-              </p>
+
+              <div class="overflow-y-auto pr-1 space-y-6 flex-1">
+                <div v-if="file.description && file.description !== ''">
+                  <h4
+                    class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-1.5"
+                  >
+                    {{ t("general.description", "Description") }}
+                  </h4>
+                  <p
+                    class="text-sm leading-relaxed text-muted-foreground break-words"
+                  >
+                    {{ file.description }}
+                  </p>
+                </div>
+
+                <div>
+                  <h4
+                    class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-2.5"
+                  >
+                    {{ t("prints.linkedProductions", "Linked Productions") }}
+                  </h4>
+
+                  <div
+                    v-if="isLoadingProductions"
+                    class="text-xs text-muted-foreground animate-pulse py-1"
+                  >
+                    Loading productions...
+                  </div>
+
+                  <div
+                    v-else-if="linkedProductions.length"
+                    class="flex flex-wrap gap-2"
+                  >
+                    <NuxtLink
+                      v-for="prod in linkedProductions"
+                      :key="prod.id"
+                      :to="ROUTES.productions.byId(prod.id)"
+                      class="text-xs font-medium px-3 py-1.5 rounded-full border border-border bg-muted hover:border-accent hover:text-accent transition-colors duration-150"
+                    >
+                      {{ prod.titel }}
+                    </NuxtLink>
+                  </div>
+
+                  <div v-else class="text-xs italic text-muted-foreground py-1">
+                    {{
+                      t(
+                        "prints.noLinkedProductions",
+                        "No productions linked to this file.",
+                      )
+                    }}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </Transition>

--- a/frontend/app/components/prints/FileGridItem.vue
+++ b/frontend/app/components/prints/FileGridItem.vue
@@ -126,7 +126,7 @@ onUnmounted(() => {
               </button>
               <!-- Title -->
               <p
-                class="font-brand text-md font-bold uppercase tracking-widest mb-6 pr-8 shrink-0"
+                class="font-brand text-base font-bold uppercase tracking-widest mb-6 pr-8 shrink-0"
               >
                 {{ file.titel }}
               </p>

--- a/frontend/app/components/prints/FileGridItem.vue
+++ b/frontend/app/components/prints/FileGridItem.vue
@@ -9,7 +9,7 @@
  *    :file="file"
  * />
  */
-import { ref, watch, onUnmounted } from "vue";
+import { ref, watch, onMounted, computed, onUnmounted } from "vue";
 import type { PrintItemView, ProductionView } from "@repo/common";
 import { Info, X } from "lucide-vue-next";
 import { useProductionApi } from "~/composables/useProductionApi"; // Uses your existing production composable
@@ -50,15 +50,30 @@ const loadLinkedProductions = async () => {
   }
 };
 
+const hasInfoAvailable = computed(() => {
+  const hasDescription =
+    props.file.description && props.file.description !== "";
+  const hasProductions = linkedProductions.value.length > 0;
+  return hasDescription || hasProductions || isLoadingProductions.value;
+});
+
+onMounted(() => {
+  loadLinkedProductions();
+});
+
+watch(
+  () => props.file?.id,
+  () => {
+    loadLinkedProductions();
+  },
+);
+
 watch(showInfo, (val) => {
   // Prevents scrolling when description is opened
   // (paddingRight compensates for the scrollbar width to prevent the layout from shifting)
   if (val) {
     document.body.style.paddingRight = `${window.innerWidth - document.documentElement.clientWidth}px`;
     document.body.style.overflow = "hidden";
-
-    // Lazy load the productions
-    loadLinkedProductions();
   } else {
     document.body.style.paddingRight = "";
     document.body.style.overflow = "";
@@ -83,7 +98,7 @@ onUnmounted(() => {
       </div>
       <!-- Info button -->
       <button
-        v-if="file.description && file.description != ''"
+        v-if="hasInfoAvailable"
         @click.stop="showInfo = true"
         class="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 hover:bg-black/70 flex items-center justify-center transition-colors z-10"
       >
@@ -111,28 +126,33 @@ onUnmounted(() => {
               </button>
               <!-- Title -->
               <p
-                class="text-[11px] font-bold uppercase tracking-widest mb-3 pr-8 shrink-0"
+                class="font-brand text-md font-bold uppercase tracking-widest mb-6 pr-8 shrink-0"
               >
                 {{ file.titel }}
               </p>
 
-              <div class="overflow-y-auto pr-1 space-y-6 flex-1">
+              <div
+                class="overflow-y-auto pr-2 space-y-6 flex-1 custom-scrollbar"
+              >
                 <div v-if="file.description && file.description !== ''">
                   <h4
-                    class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-1.5"
+                    class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-2 border-b border-border pb-1"
                   >
                     {{ t("general.description", "Description") }}
                   </h4>
                   <p
-                    class="text-sm leading-relaxed text-muted-foreground break-words"
+                    class="text-sm leading-relaxed text-muted-foreground break-words pt-1"
                   >
                     {{ file.description }}
                   </p>
                 </div>
 
-                <div>
+                <div
+                  v-if="isLoadingProductions || linkedProductions.length"
+                  class="flex flex-col"
+                >
                   <h4
-                    class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-2.5"
+                    class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-4 border-b border-border pb-1"
                   >
                     {{ t("prints.linkedProductions", "Linked Productions") }}
                   </h4>
@@ -146,25 +166,15 @@ onUnmounted(() => {
 
                   <div
                     v-else-if="linkedProductions.length"
-                    class="flex flex-wrap gap-2"
+                    class="flex flex-col gap-4"
                   >
-                    <NuxtLink
+                    <ProductionListViewItem
                       v-for="prod in linkedProductions"
                       :key="prod.id"
-                      :to="ROUTES.productions.byId(prod.id)"
-                      class="text-xs font-medium px-3 py-1.5 rounded-full border border-border bg-muted hover:border-accent hover:text-accent transition-colors duration-150"
-                    >
-                      {{ prod.titel }}
-                    </NuxtLink>
-                  </div>
-
-                  <div v-else class="text-xs italic text-muted-foreground py-1">
-                    {{
-                      t(
-                        "prints.noLinkedProductions",
-                        "No productions linked to this file.",
-                      )
-                    }}
+                      :production-view="prod"
+                      :is-admin="false"
+                      @click="showInfo = false"
+                    />
                   </div>
                 </div>
               </div>
@@ -174,7 +184,6 @@ onUnmounted(() => {
       </Teleport>
     </div>
 
-    <!-- File info -->
     <div class="mt-2">
       <p
         :class="[

--- a/frontend/app/components/prints/FileGridItem.vue
+++ b/frontend/app/components/prints/FileGridItem.vue
@@ -138,7 +138,7 @@ onUnmounted(() => {
                   <h4
                     class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-2 border-b border-border pb-1"
                   >
-                    {{ t("general.description", "Description") }}
+                    {{ t("prints.description") }}
                   </h4>
                   <p
                     class="text-sm leading-relaxed text-muted-foreground break-words pt-1"
@@ -154,7 +154,7 @@ onUnmounted(() => {
                   <h4
                     class="text-xs font-bold uppercase text-muted-foreground tracking-wider mb-4 border-b border-border pb-1"
                   >
-                    {{ t("prints.linkedProductions", "Linked Productions") }}
+                    {{ t("prints.relatedProductions") }}
                   </h4>
 
                   <div

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -262,7 +262,9 @@
     "pagination": "Pagination",
     "page_label": "Page",
     "of_pages": "of {total}",
-    "new": "New print"
+    "new": "New print",
+    "description": "description",
+    "relatedProductions": "Related productions"
   },
   "admin": {
     "finish": "Finish",

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -264,7 +264,9 @@
     "pagination": "Paginering",
     "page_label": "Pagina",
     "of_pages": "van {total}",
-    "new": "Nieuw drukwerk"
+    "new": "Nieuw drukwerk",
+    "description": "omschrijving",
+    "relatedProductions": "Gerelateerde producties"
   },
   "admin": {
     "finish": "Voltooien",


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [ ] this PR implements a new feature
* Displays linked productions (when the info button is clicked) on the prints page, right below the description.

## 🔍 HOW TO TEST
1. Go to the **Prints** page.
2. Find a print that has linked productions (for example, the cat print or AD2).
3. Click the info (`i`) button on the print card.

## ⚠️ REMAINING ISSUES
- error when print is clicked (404)