### PR TITLE
Page skeletons

### DIFF
--- a/frontend/app/components/admin/blogs/ListView.vue
+++ b/frontend/app/components/admin/blogs/ListView.vue
@@ -90,7 +90,7 @@ function handleJump() {
 // Blog data
 
 const blogs = ref<BlogView[]>([]);
-const loading = ref(false);
+const loading = ref(true);
 const error = ref<string | null>(null);
 
 /**
@@ -238,25 +238,6 @@ async function handleDelete(blog: BlogView) {
     />
 
     <section class="bg-background pt-6 pb-6 h-full">
-      <div class="page-container flex items-center justify-between mb-6">
-        <div>
-          <p
-            v-if="!loading && totalItems > 0"
-            class="font-brand text-2xl font-black text-foreground"
-          >
-            {{ totalItems }} {{ t("general.results") }}
-          </p>
-        </div>
-
-        <NuxtLink
-          :to="ROUTES.admin.stories.create"
-          class="inline-flex items-center gap-1.5 px-3 py-2.5 rounded-lg bg-accent border-2 border-accent text-accent-foreground font-brand font-black text-[11px] uppercase tracking-widest leading-none hover:bg-transparent hover:text-accent transition"
-        >
-          <Plus :size="15" />
-          {{ t("admin.blogs.new") }}
-        </NuxtLink>
-      </div>
-
       <!-- Error banner -->
       <div
         v-if="error"
@@ -265,14 +246,8 @@ async function handleDelete(blog: BlogView) {
         {{ error }}
       </div>
 
-      <!-- Loading skeleton: one placeholder per PAGE_SIZE slot -->
-      <div v-if="loading" class="space-y-3">
-        <div
-          v-for="i in PAGE_SIZE"
-          :key="i"
-          class="h-[136px] bg-muted rounded-xl animate-pulse"
-        />
-      </div>
+      <!-- Loading skeleton -->
+      <AdminBlogsStoriesSkeleton v-if="loading" />
 
       <!-- Empty state -->
       <div v-else-if="!blogs.length" class="py-20 text-center">
@@ -288,8 +263,28 @@ async function handleDelete(blog: BlogView) {
         </p>
       </div>
 
-      <!-- Story list: each item exposes edit/delete actions in the card -->
-      <div v-else class="page-container space-y-3">
+      <div v-else>
+        <!-- Story list: each item exposes edit/delete actions in the card -->
+        <div class="page-container flex items-center justify-between mb-6">
+          <div>
+            <p
+              v-if="!loading && totalItems > 0"
+              class="font-brand text-2xl font-black text-foreground"
+            >
+              {{ totalItems }} {{ t("general.results") }}
+            </p>
+          </div>
+
+          <NuxtLink
+            :to="ROUTES.admin.stories.create"
+            class="inline-flex items-center gap-1.5 px-3 py-2.5 rounded-lg bg-accent border-2 border-accent text-accent-foreground font-brand font-black text-[11px] uppercase tracking-widest leading-none hover:bg-transparent hover:text-accent transition"
+          >
+            <Plus :size="15" />
+            {{ t("admin.blogs.new") }}
+          </NuxtLink>
+        </div>
+      </div>
+      <div class="page-container space-y-3">
         <!--
           BlogsStoryListItem is the same card used on the public stories page.
           `is-admin` switches it to show edit/delete buttons instead of a link.

--- a/frontend/app/components/admin/blogs/StoriesSkeleton.vue
+++ b/frontend/app/components/admin/blogs/StoriesSkeleton.vue
@@ -1,0 +1,78 @@
+<!--
+  components/admin/blogs/StoriesSkeleton.vue
+  =====================================================
+  Animated loading skeleton for the first page fetch.
+-->
+<script lang="ts" setup>
+const skel = "bg-muted-foreground/20 animate-pulse rounded";
+const skel_muted = "bg-muted animate-pulse rounded";
+</script>
+
+<template>
+  <div aria-busy="true" aria-label="Loading admin stories">
+    <section class="bg-background pt-6 pb-6 h-full">
+      <div class="page-container">
+        <div class="flex items-center justify-between mb-6">
+          <!-- "Results count" -->
+          <div :class="`h-7 w-32 ${skel}`" />
+          <!-- New story button -->
+          <div :class="`h-10 w-32 ${skel}`" />
+        </div>
+
+        <!-- Story list items (10) -->
+        <div class="space-y-3">
+          <div
+            v-for="i in 10"
+            :key="i"
+            class="flex overflow-hidden rounded-xl border border-border bg-card h-[136px]"
+          >
+            <!-- Thumbnail -->
+            <div :class="`w-32 sm:w-52 shrink-0 ${skel} rounded-none`" />
+
+            <!-- Info -->
+            <div class="flex-1 min-w-0 flex flex-col justify-between px-5 py-4">
+              <div class="flex items-start justify-between gap-3">
+                <div class="space-y-2 flex-1">
+                  <!-- Title -->
+                  <div :class="`h-4 ${skel} w-3/4`" />
+                  <!-- Description -->
+                  <div :class="`h-3 ${skel} w-full`" />
+                  <div :class="`h-3 ${skel} w-4/5`" />
+                </div>
+
+                <!-- Edit + delete buttons -->
+                <div class="flex items-center gap-2 shrink-0">
+                  <div :class="`h-10 w-10 ${skel}`" />
+                  <div :class="`h-10 w-10 ${skel}`" />
+                </div>
+              </div>
+
+              <!-- Date -->
+              <div :class="`h-3 ${skel} w-24`" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination -->
+        <div class="flex items-center justify-between mt-16">
+          <!-- SeriesPageJumper -->
+          <div class="flex items-center gap-2">
+            <div :class="`h-3 w-10 ${skel}`" />
+            <div :class="`w-14 h-9 ${skel} rounded-md`" />
+            <div :class="`h-3 w-14 ${skel}`" />
+          </div>
+
+          <!-- SeriesPagination -->
+          <div
+            class="inline-flex items-stretch rounded-md border-2 border-foreground/20 overflow-hidden"
+          >
+            <div v-for="j in 5" :key="j" class="flex items-center">
+              <div :class="`w-11 h-8 ${skel}`" />
+              <div v-if="j < 5" class="w-[2px] h-8 bg-foreground/20" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/frontend/app/components/admin/prints/PrintsSkeleton.vue
+++ b/frontend/app/components/admin/prints/PrintsSkeleton.vue
@@ -1,0 +1,71 @@
+<!--
+  components/admin/prints/AdminPrintsSkeleton.vue
+  ===============================================
+  Animated loading skeleton for the first page fetch.
+-->
+<script lang="ts" setup>
+const skel = "bg-muted-foreground/20 animate-pulse rounded";
+const skel_muted = "bg-muted animate-pulse rounded";
+</script>
+
+<template>
+  <div aria-busy="true" aria-label="Loading prints">
+    <section class="bg-background w-full h-full pt-6">
+      <div class="page-container flex items-center justify-between mb-0">
+        <!-- "Results count" -->
+        <div :class="`h-7 w-32 ${skel}`" />
+        <!-- New print button -->
+        <div :class="`h-10 w-32 ${skel}`" />
+      </div>
+
+      <!-- File list -->
+      <div class="page-container py-6">
+        <div class="rounded-lg border border-border overflow-hidden">
+          <div
+            v-for="i in 15"
+            :key="i"
+            class="flex items-center gap-4 px-4 py-3 border-t border-border bg-card first:border-t-0"
+          >
+            <!-- File icon -->
+            <div :class="`w-9 h-9 rounded-md shrink-0 ${skel}`" />
+
+            <!-- File info -->
+            <div class="flex-1 min-w-0 space-y-1.5">
+              <!-- File name -->
+              <div :class="`h-3.5 ${skel} w-1/2`" />
+              <!-- Type + date -->
+              <div :class="`h-2.5 ${skel} w-1/3`" />
+            </div>
+
+            <!-- Action buttons -->
+            <div class="flex items-center gap-2 shrink-0">
+              <div :class="`h-9 w-9 ${skel}`" />
+              <div :class="`h-9 w-9 ${skel}`" />
+              <div :class="`h-9 w-9 ${skel}`" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Pagination -->
+        <div class="flex items-center justify-between mt-16">
+          <!-- SeriesPageJumper -->
+          <div class="flex items-center gap-2">
+            <div :class="`h-3 w-10 ${skel}`" />
+            <div :class="`w-14 h-9 ${skel} rounded-md`" />
+            <div :class="`h-3 w-14 ${skel}`" />
+          </div>
+
+          <!-- SeriesPagination -->
+          <div
+            class="inline-flex items-stretch rounded-md border-2 border-foreground/20 overflow-hidden"
+          >
+            <div v-for="j in 5" :key="j" class="flex items-center">
+              <div :class="`w-11 h-8 ${skel}`" />
+              <div v-if="j < 5" class="w-[2px] h-8 bg-foreground/20" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/frontend/app/components/series/SeriesDetailSkeleton.vue
+++ b/frontend/app/components/series/SeriesDetailSkeleton.vue
@@ -1,0 +1,109 @@
+<!--
+  components/series/SeriesDetailSkeleton.vue
+  ==========================================
+  Animated loading skeleton for the first page fetch.
+-->
+
+<script lang="ts" setup>
+const skel = "bg-muted-foreground/20 animate-pulse rounded";
+const skel_muted = "bg-muted animate-pulse rounded";
+</script>
+
+<template>
+  <div
+    class="min-h-screen bg-background text-foreground"
+    aria-busy="true"
+    aria-label="Loading series"
+  >
+    <!-- Header section -->
+    <section class="w-full border-b border-border bg-muted py-16 lg:py-24">
+      <div class="page-container w-full">
+        <!-- Back button -->
+        <div class="flex items-center gap-1 mb-8">
+          <div :class="`h-3 w-3 ${skel}`" />
+          <div :class="`h-3 w-12 ${skel}`" />
+        </div>
+
+        <!-- Title -->
+        <div class="space-y-3 mb-6">
+          <div :class="`h-14 lg:h-20 w-2/3 ${skel}`" />
+        </div>
+
+        <!-- Description -->
+        <div class="max-w-5xl space-y-3">
+          <div :class="`h-5 w-full ${skel}`" />
+          <div :class="`h-5 w-full ${skel}`" />
+          <div :class="`h-5 w-4/5  ${skel}`" />
+          <div :class="`h-5 w-full ${skel}`" />
+        </div>
+      </div>
+    </section>
+
+    <!-- Content section -->
+    <section class="py-20">
+      <div class="page-container">
+        <!-- Production count -->
+        <div :class="`h-3 w-32 ${skel} mb-6`" />
+
+        <!-- Linked productions -->
+        <section class="page-container pb-14 pt-10">
+          <!-- Title -->
+          <div class="mb-6">
+            <div :class="`h-6 w-48 ${skel}`" />
+          </div>
+
+          <!-- Production list items -->
+          <div class="flex flex-col gap-4">
+            <div
+              v-for="i in 3"
+              :key="i"
+              class="flex items-center gap-4 p-4 rounded-xl border border-card-border bg-card"
+            >
+              <!-- Thumbnail -->
+              <div :class="`w-48 h-32 ${skel} rounded-lg shrink-0`" />
+
+              <!-- Info -->
+              <div :class="`flex-1 min-w-0 space-y-3`">
+                <!-- Title -->
+                <div :class="`h-7 ${skel} w-2/3`" />
+                <!-- Artist -->
+                <div :class="`h-4 ${skel} w-1/3`" />
+                <!-- Calender icon + date -->
+                <div class="flex items-center gap-2 mt-2">
+                  <div :class="`w-4 h-4 ${skel}`" />
+                  <div :class="`h-4 ${skel} w-40`" />
+                </div>
+                <!-- Tags -->
+                <div class="flex gap-2 mt-2">
+                  <div :class="`h-5 w-16 ${skel} rounded-full`" />
+                  <div :class="`h-5 w-20 ${skel} rounded-full`" />
+                  <div :class="`h-5 w-14 ${skel} rounded-full`" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Pagination -->
+        <div class="flex items-center justify-between mt-16">
+          <!-- SeriesPageJumper -->
+          <div class="flex items-center gap-2">
+            <div :class="`h-3 w-10 ${skel}`" />
+            <div :class="`w-14 h-9 ${skel} rounded-md`" />
+            <div :class="`h-3 w-14 ${skel}`" />
+          </div>
+
+          <!-- SeriesPagination -->
+          <div
+            class="inline-flex items-stretch rounded-md border-2 border-foreground/20 overflow-hidden"
+          >
+            <div v-for="j in 5" :key="j" class="flex items-center">
+              <div :class="`w-11 h-8 ${skel}`" />
+              <div v-if="j < 5" class="w-[2px] h-8 bg-foreground/20" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/frontend/app/pages/admin/prints/index.vue
+++ b/frontend/app/pages/admin/prints/index.vue
@@ -105,8 +105,10 @@ onMounted(() => {
       @update:types="activeFilter = $event"
     />
 
+    <AdminPrintsSkeleton v-if="loading" />
+
     <!-- TotalItems + Add button -->
-    <section class="bg-background w-full h-full pt-6">
+    <section v-else class="bg-background w-full h-full pt-6">
       <div class="page-container flex items-center justify-between mb-0">
         <div>
           <p

--- a/frontend/app/pages/series/[id].vue
+++ b/frontend/app/pages/series/[id].vue
@@ -101,7 +101,9 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <main class="min-h-screen bg-background text-foreground">
+  <SeriesDetailSkeleton v-if="loading && !series" />
+
+  <main v-else class="min-h-screen bg-background text-foreground">
     <!-- Header section -->
     <section class="w-full border-b border-border bg-muted py-16 lg:py-24">
       <div class="page-container w-full">
@@ -177,8 +179,18 @@ onBeforeUnmount(() => {
           v-if="totalPages > 1"
           class="flex items-center justify-between mt-16"
         >
-          <SeriesPageJumper />
-          <SeriesPagination />
+          <SeriesPageJumper
+            :current-page="currentPage"
+            :total-pages="totalPages"
+            :loading="loading"
+            @go-to-page="currentPage = $event"
+          />
+          <SeriesPagination
+            :current-page="currentPage"
+            :total-pages="totalPages"
+            :loading="loading"
+            @go-to-page="currentPage = $event"
+          />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [ ] this PR adds a bunch of skeletons to pages that don't have one yet, to prevent flashing/footer jumping:
- series detail page
- admin stories page (required a bit of refactoring/moving code around)
- admin prints page

The pagination disappeared on the series detail page, so I've added it back.

## 🛠️ TESTING
No tests are written for this PR.

## 📝 DOCUMENTATION
\-

## 🔍 HOW TO TEST
- To look at each skeleton you can set `v-if="true"` where it is used, or just paste a `<SkeletonComponent />` somewhere on the page. Most important is that the footers don't "jump" on initial page load.
- Let me know if any pages still have the flashing problem, I've looked through the pages myself but I could still have missed one.

## ⚠️ REMAINING ISSUES
\-

## 📸 SCREENSHOTS (if necessary):
\-

## ✅ CLOSED ISSUES
- #522
