### PR TITLE
clickable tags in the production detail page to filter the productions on the specific tag

### DIFF
--- a/frontend/app/pages/productions/[id].vue
+++ b/frontend/app/pages/productions/[id].vue
@@ -19,6 +19,7 @@ const { t, locale } = useI18n();
 const router = useRouter();
 const { getById, getTags, getBlogs, getMediaGallery } = useProductionApi();
 const { getMainImageCrop, getCarouselImageCrops } = useGallery();
+const { tagIds } = useArchiveView();
 const route = useRoute();
 
 const goBack = () => {
@@ -27,6 +28,14 @@ const goBack = () => {
   } else {
     router.push(ROUTES.productions.base); // Fallback
   }
+};
+
+const goToTaggedSearch = (tagId: number) => {
+  tagIds.value = [tagId];
+  router.push({
+    path: ROUTES.productions.base,
+    query: { tag: String(tagId), page: "1" },
+  });
 };
 
 const productionId = computed(() => {
@@ -240,12 +249,14 @@ const isValid = (val: any) => {
           class="flex flex-wrap gap-3 mt-8"
         >
           <template v-for="tag in tags" :key="tag.id">
-            <span
+            <button
               v-if="isValid(tag.tag)"
+              type="button"
               class="bg-accent text-white px-5 py-2 rounded-full text-[10px] font-black uppercase tracking-[1px]"
+              @click="goToTaggedSearch(tag.id)"
             >
               {{ tag.tag }}
-            </span>
+            </button>
           </template>
         </div>
       </div>

--- a/frontend/app/pages/productions/[id].vue
+++ b/frontend/app/pages/productions/[id].vue
@@ -252,7 +252,7 @@ const isValid = (val: any) => {
             <button
               v-if="isValid(tag.tag)"
               type="button"
-              class="bg-accent text-white px-5 py-2 rounded-full text-[10px] font-black uppercase tracking-[1px]"
+              class="bg-accent text-white px-5 py-2 rounded-full text-[10px] font-black uppercase tracking-[1px] cursor-pointer transition-all duration-200 hover:brightness-110 hover:scale-110 hover:shadow-2xl hover:-translate-y-1"
               @click="goToTaggedSearch(tag.id)"
             >
               {{ tag.tag }}


### PR DESCRIPTION
## 🎯 MAIN GOAL
- [X] this PR implements a new feature
when clicking on a tag on the production page, you will filter the productions on that specific tag. With correct back-button navigation.


## 🛠️ TESTING
none

**Missing tests:**
all

## 🔍 HOW TO TEST
Go to a production detail page with a tag and click on a tag, also click on the "go back button", to verify the correct navigation to the production.

## ✅ CLOSED ISSUES
- #509 
