### PR TITLE
sort out of filters

### DIFF
--- a/frontend/app/components/YearRangeSlider.vue
+++ b/frontend/app/components/YearRangeSlider.vue
@@ -254,6 +254,12 @@ const yearB = computed(() => fracToYear(fracB.value));
   cursor: grabbing;
 }
 
+.yr-slider--dragging .yr-handle:hover,
+.yr-slider--dragging .yr-handle:focus-visible {
+  box-shadow: none;
+  transform: translate(-50%, -50%);
+}
+
 .yr-handle-label {
   position: absolute;
   bottom: calc(100% + 6px);

--- a/frontend/app/components/YearRangeSlider.vue
+++ b/frontend/app/components/YearRangeSlider.vue
@@ -1,0 +1,265 @@
+<!--
+  YearRangeSlider.vue
+  ====================
+  Dual-handle range slider for selecting a range of years.
+
+  Props:
+  - modelValue:  [fromYear, toYear] — always sorted (min first)
+  - oldestYear:  minimum selectable year
+  - newestYear:  maximum selectable year
+
+  Emits:
+  - update:modelValue — [fromYear, toYear] sorted whenever a handle moves
+
+  Design notes:
+  - Two independent handles that can freely cross each other (smooth crossing UX)
+  - Handles snap to integer years on pointer-up
+  - Each handle shows its current year as a label above it
+  - The filled track segment is always drawn between the two handles
+-->
+
+<script lang="ts" setup>
+const props = defineProps<{
+  modelValue: [number, number];
+  oldestYear: number;
+  newestYear: number;
+}>();
+
+const emit = defineEmits<{
+  "update:modelValue": [value: [number, number]];
+}>();
+
+const trackRef = ref<HTMLElement | null>(null);
+const isDragging = ref(false);
+
+function yearToFrac(year: number): number {
+  const range = props.newestYear - props.oldestYear;
+  if (range <= 0) return 0;
+  return (year - props.oldestYear) / range;
+}
+
+function fracToYear(frac: number): number {
+  const range = props.newestYear - props.oldestYear;
+  return Math.round(props.oldestYear + frac * range);
+}
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+const fracA = ref(yearToFrac(props.modelValue[0]));
+const fracB = ref(yearToFrac(props.modelValue[1]));
+
+// Sync handle positions from external modelValue (skip during active drag)
+watch(
+  () => props.modelValue,
+  ([from, to]) => {
+    if (!isDragging.value) {
+      fracA.value = yearToFrac(from);
+      fracB.value = yearToFrac(to);
+    }
+  },
+  { deep: true },
+);
+
+// Re-sync when year bounds change (e.g., loaded asynchronously)
+watch([() => props.oldestYear, () => props.newestYear], () => {
+  if (!isDragging.value) {
+    fracA.value = yearToFrac(props.modelValue[0]);
+    fracB.value = yearToFrac(props.modelValue[1]);
+  }
+});
+
+function getFracFromEvent(clientX: number): number {
+  if (!trackRef.value) return 0;
+  const rect = trackRef.value.getBoundingClientRect();
+  return clamp((clientX - rect.left) / rect.width, 0, 1);
+}
+
+function startDrag(which: "a" | "b", event: PointerEvent) {
+  event.preventDefault();
+  isDragging.value = true;
+  const target = event.currentTarget as HTMLElement;
+  target.setPointerCapture(event.pointerId);
+
+  function onMove(e: PointerEvent) {
+    const f = getFracFromEvent(e.clientX);
+    if (which === "a") fracA.value = f;
+    else fracB.value = f;
+
+    const yA = fracToYear(fracA.value);
+    const yB = fracToYear(fracB.value);
+    emit("update:modelValue", [Math.min(yA, yB), Math.max(yA, yB)]);
+  }
+
+  function onUp() {
+    // Snap handles to exact year positions
+    fracA.value = yearToFrac(fracToYear(fracA.value));
+    fracB.value = yearToFrac(fracToYear(fracB.value));
+    isDragging.value = false;
+    target.removeEventListener("pointermove", onMove);
+    target.removeEventListener("pointerup", onUp);
+  }
+
+  target.addEventListener("pointermove", onMove);
+  target.addEventListener("pointerup", onUp);
+}
+
+// Handle keyboard navigation
+function onKeyDown(which: "a" | "b", event: KeyboardEvent) {
+  const step = 1 / Math.max(props.newestYear - props.oldestYear, 1);
+  let delta = 0;
+  if (event.key === "ArrowLeft" || event.key === "ArrowDown") delta = -step;
+  else if (event.key === "ArrowRight" || event.key === "ArrowUp") delta = step;
+  else return;
+
+  event.preventDefault();
+  if (which === "a") fracA.value = clamp(fracA.value + delta, 0, 1);
+  else fracB.value = clamp(fracB.value + delta, 0, 1);
+
+  const yA = fracToYear(fracA.value);
+  const yB = fracToYear(fracB.value);
+  emit("update:modelValue", [Math.min(yA, yB), Math.max(yA, yB)]);
+}
+
+const yearA = computed(() => fracToYear(fracA.value));
+const yearB = computed(() => fracToYear(fracB.value));
+const leftFrac = computed(() => Math.min(fracA.value, fracB.value));
+const rightFrac = computed(() => Math.max(fracA.value, fracB.value));
+</script>
+
+<template>
+  <div class="yr-slider" :class="{ 'yr-slider--dragging': isDragging }">
+    <div ref="trackRef" class="yr-track">
+      <div class="yr-track-bg" />
+      <div
+        class="yr-track-fill"
+        :style="{
+          left: `${leftFrac * 100}%`,
+          width: `${(rightFrac - leftFrac) * 100}%`,
+        }"
+      />
+
+      <!-- Handle A -->
+      <button
+        class="yr-handle"
+        :style="{ left: `${fracA * 100}%` }"
+        role="slider"
+        :aria-valuenow="yearA"
+        :aria-valuemin="oldestYear"
+        :aria-valuemax="newestYear"
+        tabindex="0"
+        @pointerdown.prevent="startDrag('a', $event)"
+        @keydown="onKeyDown('a', $event)"
+      >
+        <span class="yr-handle-label">{{ yearA }}</span>
+      </button>
+
+      <!-- Handle B -->
+      <button
+        class="yr-handle"
+        :style="{ left: `${fracB * 100}%` }"
+        role="slider"
+        :aria-valuenow="yearB"
+        :aria-valuemin="oldestYear"
+        :aria-valuemax="newestYear"
+        tabindex="0"
+        @pointerdown.prevent="startDrag('b', $event)"
+        @keydown="onKeyDown('b', $event)"
+      >
+        <span class="yr-handle-label">{{ yearB }}</span>
+      </button>
+    </div>
+
+    <!-- Track endpoint labels -->
+    <div class="yr-endpoints">
+      <span>{{ oldestYear }}</span>
+      <span>{{ newestYear }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.yr-slider {
+  padding: 28px 8px 4px;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.yr-track {
+  position: relative;
+  height: 4px;
+}
+
+.yr-track-bg {
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+  background: var(--border);
+}
+
+.yr-track-fill {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+}
+
+.yr-handle {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--background);
+  border: 2px solid var(--accent);
+  cursor: grab;
+  touch-action: none;
+  padding: 0;
+  outline: none;
+  z-index: 1;
+  transition:
+    box-shadow 0.1s,
+    transform 0.1s;
+}
+
+.yr-handle:hover,
+.yr-handle:focus-visible {
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
+  transform: translate(-50%, -50%) scale(1.15);
+}
+
+.yr-slider--dragging .yr-handle {
+  cursor: grabbing;
+}
+
+.yr-handle-label {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-brand, "ABCMonumentGrotesk", sans-serif);
+  font-weight: 900;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.yr-endpoints {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-family: var(--font-brand, "ABCMonumentGrotesk", sans-serif);
+  font-weight: 900;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  opacity: 0.5;
+}
+</style>

--- a/frontend/app/components/YearRangeSlider.vue
+++ b/frontend/app/components/YearRangeSlider.vue
@@ -4,18 +4,19 @@
   Dual-handle range slider for selecting a range of years.
 
   Props:
-  - modelValue:  [fromYear, toYear] — always sorted (min first)
-  - oldestYear:  minimum selectable year
-  - newestYear:  maximum selectable year
+  - modelValue:  [fromYear, toYear] — always left ≤ right
+  - oldestYear:  minimum selectable year (left boundary)
+  - newestYear:  maximum selectable year (right boundary)
 
   Emits:
-  - update:modelValue — [fromYear, toYear] sorted whenever a handle moves
+  - update:modelValue — [fromYear, toYear] emitted ONLY on pointer-up (not during drag)
+                        so consumers don't fire API calls on every pixel moved.
 
   Design notes:
-  - Two independent handles that can freely cross each other (smooth crossing UX)
-  - Handles snap to integer years on pointer-up
-  - Each handle shows its current year as a label above it
-  - The filled track segment is always drawn between the two handles
+  - Handle A is always the left (from) handle; handle B is always the right (to) handle.
+  - Neither handle can cross the other (hard-clamped during drag).
+  - Handles snap to integer years on release.
+  - The right handle's year label is hidden when both handles share the same year.
 -->
 
 <script lang="ts" setup>
@@ -47,10 +48,12 @@ function clamp(v: number, lo: number, hi: number) {
   return Math.max(lo, Math.min(hi, v));
 }
 
+// fracA = left (from) handle, fracB = right (to) handle — A is always ≤ B
 const fracA = ref(yearToFrac(props.modelValue[0]));
 const fracB = ref(yearToFrac(props.modelValue[1]));
 
-// Sync handle positions from external modelValue (skip during active drag)
+// Sync handle positions from external modelValue (never during an active drag,
+// since we only emit on release and don't want mid-drag interference).
 watch(
   () => props.modelValue,
   ([from, to]) => {
@@ -62,7 +65,7 @@ watch(
   { deep: true },
 );
 
-// Re-sync when year bounds change (e.g., loaded asynchronously)
+// Re-sync when year bounds change (e.g., loaded asynchronously after mount)
 watch([() => props.oldestYear, () => props.newestYear], () => {
   if (!isDragging.value) {
     fracA.value = yearToFrac(props.modelValue[0]);
@@ -82,21 +85,36 @@ function startDrag(which: "a" | "b", event: PointerEvent) {
   const target = event.currentTarget as HTMLElement;
   target.setPointerCapture(event.pointerId);
 
+  // When handles overlap, the top handle (B) captures all clicks.
+  // We resolve the actual handle on the first move based on direction.
+  let activeHandle = which;
+
   function onMove(e: PointerEvent) {
     const f = getFracFromEvent(e.clientX);
-    if (which === "a") fracA.value = f;
-    else fracB.value = f;
-
-    const yA = fracToYear(fracA.value);
-    const yB = fracToYear(fracB.value);
-    emit("update:modelValue", [Math.min(yA, yB), Math.max(yA, yB)]);
+    if (fracA.value === fracB.value) {
+      if (f < fracA.value) activeHandle = "a";
+      else if (f > fracB.value) activeHandle = "b";
+    }
+    if (activeHandle === "a") {
+      fracA.value = clamp(f, 0, fracB.value);
+    } else {
+      fracB.value = clamp(f, fracA.value, 1);
+    }
+    // No emit here — API call only fires on release (see onUp)
   }
 
   function onUp() {
-    // Snap handles to exact year positions
+    // Snap both handles to the nearest integer year position
     fracA.value = yearToFrac(fracToYear(fracA.value));
     fracB.value = yearToFrac(fracToYear(fracB.value));
     isDragging.value = false;
+
+    // Single emit after the drag ends — prevents flooding the server
+    emit("update:modelValue", [
+      fracToYear(fracA.value),
+      fracToYear(fracB.value),
+    ]);
+
     target.removeEventListener("pointermove", onMove);
     target.removeEventListener("pointerup", onUp);
   }
@@ -105,7 +123,7 @@ function startDrag(which: "a" | "b", event: PointerEvent) {
   target.addEventListener("pointerup", onUp);
 }
 
-// Handle keyboard navigation
+// Keyboard navigation — one year step per arrow key
 function onKeyDown(which: "a" | "b", event: KeyboardEvent) {
   const step = 1 / Math.max(props.newestYear - props.oldestYear, 1);
   let delta = 0;
@@ -114,40 +132,41 @@ function onKeyDown(which: "a" | "b", event: KeyboardEvent) {
   else return;
 
   event.preventDefault();
-  if (which === "a") fracA.value = clamp(fracA.value + delta, 0, 1);
-  else fracB.value = clamp(fracB.value + delta, 0, 1);
 
-  const yA = fracToYear(fracA.value);
-  const yB = fracToYear(fracB.value);
-  emit("update:modelValue", [Math.min(yA, yB), Math.max(yA, yB)]);
+  if (which === "a") {
+    fracA.value = clamp(fracA.value + delta, 0, fracB.value);
+  } else {
+    fracB.value = clamp(fracB.value + delta, fracA.value, 1);
+  }
+
+  emit("update:modelValue", [fracToYear(fracA.value), fracToYear(fracB.value)]);
 }
 
 const yearA = computed(() => fracToYear(fracA.value));
 const yearB = computed(() => fracToYear(fracB.value));
-const leftFrac = computed(() => Math.min(fracA.value, fracB.value));
-const rightFrac = computed(() => Math.max(fracA.value, fracB.value));
 </script>
 
 <template>
   <div class="yr-slider" :class="{ 'yr-slider--dragging': isDragging }">
     <div ref="trackRef" class="yr-track">
       <div class="yr-track-bg" />
+      <!-- Fill always goes from A (left) to B (right) — no min/max needed -->
       <div
         class="yr-track-fill"
         :style="{
-          left: `${leftFrac * 100}%`,
-          width: `${(rightFrac - leftFrac) * 100}%`,
+          left: `${fracA * 100}%`,
+          width: `${(fracB - fracA) * 100}%`,
         }"
       />
 
-      <!-- Handle A -->
+      <!-- Left (from) handle -->
       <button
         class="yr-handle"
         :style="{ left: `${fracA * 100}%` }"
         role="slider"
         :aria-valuenow="yearA"
         :aria-valuemin="oldestYear"
-        :aria-valuemax="newestYear"
+        :aria-valuemax="yearB"
         tabindex="0"
         @pointerdown.prevent="startDrag('a', $event)"
         @keydown="onKeyDown('a', $event)"
@@ -155,19 +174,19 @@ const rightFrac = computed(() => Math.max(fracA.value, fracB.value));
         <span class="yr-handle-label">{{ yearA }}</span>
       </button>
 
-      <!-- Handle B -->
+      <!-- Right (to) handle — label hidden when both handles share the same year -->
       <button
         class="yr-handle"
         :style="{ left: `${fracB * 100}%` }"
         role="slider"
         :aria-valuenow="yearB"
-        :aria-valuemin="oldestYear"
+        :aria-valuemin="yearA"
         :aria-valuemax="newestYear"
         tabindex="0"
         @pointerdown.prevent="startDrag('b', $event)"
         @keydown="onKeyDown('b', $event)"
       >
-        <span class="yr-handle-label">{{ yearB }}</span>
+        <span v-if="yearB !== yearA" class="yr-handle-label">{{ yearB }}</span>
       </button>
     </div>
 

--- a/frontend/app/components/archive/ArchiveSearchSection.vue
+++ b/frontend/app/components/archive/ArchiveSearchSection.vue
@@ -81,6 +81,7 @@ async function fetchOldestDate() {
         ? (evResp.data as any)
         : [];
 
+    // Extract all timestamps and find earliest
     const times = events
       .flatMap((e) => [e.starttime, e.endtime])
       .filter(Boolean)

--- a/frontend/app/components/archive/ArchiveSearchSection.vue
+++ b/frontend/app/components/archive/ArchiveSearchSection.vue
@@ -3,29 +3,24 @@ ArchiveSearchSection.vue
 
 Top control section for the archive page.
 Responsible for:
-- Managing search input, filters, and view mode
-- Toggling and rendering the filter panel
-- Handling tag, date, and sorting filters
-- Fetching and setting the oldest available date for the calendar
+- Passing search, sort, and date-filter state to StoryToolbar
+- Rendering the tag filter inside StoryToolbar's #extra-filters slot
+- Rendering the grid/list toggle inside StoryToolbar's #action slot (public only)
+- Fetching the oldest/newest available date for the calendar and year slider
 
 Uses:
 - useArchiveView: shared archive state (filters, view mode, etc.)
 - useProductionApi / useEventApi: to derive oldest available date
-- Calendar: date range filtering UI
+- StoryToolbar: reused search + sort + filter panel
 - TagFilter: tag selection UI
 
 Modes:
-- Public:
-  search + filters + grid/list toggle
-
-- Admin:
-  search + filters only
-  forced list view
+- Public:  search + filters + grid/list toggle
+- Admin:   search + filters only, forced list view
 -->
 <script setup lang="ts">
-import { LayoutGrid, List, X } from "lucide-vue-next";
+import { LayoutGrid, List } from "lucide-vue-next";
 import { useArchiveView } from "../../composables/useArchiveView";
-import Calendar from "~/components/DefaultCalendar.vue";
 import { useProductionApi } from "~/composables/useProductionApi";
 import { useEventApi } from "~/composables/useEventApi";
 import type { ProductionView, Event } from "@repo/common";
@@ -49,6 +44,7 @@ const {
   sortOrder,
   dateFilter,
   oldestDate,
+  newestDate,
   tagIds,
   fetchSuggestions,
 } = useArchiveView();
@@ -56,25 +52,14 @@ const {
 const { getAll: getAllProductions } = useProductionApi();
 const { getAll: getAllEvents } = useEventApi();
 
-const filterOpen = ref(false);
-const calendarKey = ref(0);
-
-// Check if any filter is currently active (used for "clear filters" button)
+// Show the ×-badge when tags are active or the date filter is custom (not the defaults)
 const hasActiveFilters = computed(() => {
   return (
     tagIds.value.length > 0 ||
     !!dateFilter.value.after ||
-    dateFilter.value.before !== getToday() // Checks whether the before date is custom or not.
+    dateFilter.value.before !== getToday()
   );
 });
-
-function clearAllFilters() {
-  // Reset all filters to default state
-  tagIds.value = [];
-  dateFilter.value = {};
-  // Force calendar component to re-render/reset
-  calendarKey.value++;
-}
 
 async function fetchOldestDate() {
   try {
@@ -96,7 +81,6 @@ async function fetchOldestDate() {
         ? (evResp.data as any)
         : [];
 
-    // Extract all timestamps and find earliest
     const times = events
       .flatMap((e) => [e.starttime, e.endtime])
       .filter(Boolean)
@@ -109,7 +93,7 @@ async function fetchOldestDate() {
         .slice(0, 10);
     }
   } catch {
-    // Non-critical: calendar still works without the oldest date
+    // Non-critical: calendar and year slider still work without the oldest date
   }
 }
 
@@ -123,125 +107,50 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="w-full border-b border-border bg-background">
-    <!-- Toolbar row -->
-    <div class="page-container py-5 flex items-stretch gap-3">
-      <!-- Search -->
-      <div class="flex-1 min-w-0 h-12">
-        <SearchBar
-          v-model="searchQuery"
-          :fetch-suggestions="fetchSuggestions"
-          :limit="15"
-          :scroll-limit="5"
-          :placeholder="t('archive.search_placeholder')"
-        />
-      </div>
+  <!--
+    StoryToolbar handles: search bar, sort select, filter toggle button, ×-badge,
+    year range slider, calendar, and the collapsible filter panel transition.
 
-      <!-- Sort order select -->
-      <div class="shrink-0 h-12">
-        <label class="sr-only">{{ t("archive.sortLabel") }}</label>
-        <select
-          v-model="sortOrder"
-          class="h-12 px-3 rounded bg-muted border border-border text-[10px] font-brand font-black uppercase tracking-widest text-muted-foreground focus:outline-none cursor-pointer transition-colors hover:border-foreground/30"
-        >
-          <option value="newest">{{ t("archive.sortNewest") }}</option>
-          <option value="oldest">{{ t("archive.sortOldest") }}</option>
-        </select>
-      </div>
-
-      <!-- Filter toggle + badge -->
-      <div class="relative">
-        <button
-          type="button"
-          :class="[
-            'btn-outline h-12 px-5 gap-2 shrink-0 flex items-center justify-center',
-            filterOpen && '!bg-foreground !text-background !border-foreground',
-          ]"
-          :aria-expanded="filterOpen"
-          @click="filterOpen = !filterOpen"
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M1 2h10L7 6.5V10.5L5 9.5V6.5L1 2z"
-              stroke="currentColor"
-              stroke-width="1.2"
-              stroke-linejoin="round"
-            />
-          </svg>
-          <span>{{ t("general.filters") }}</span>
-        </button>
-
-        <!-- Clear filters badge -->
-        <button
-          v-if="hasActiveFilters"
-          @click.stop="clearAllFilters"
-          class="absolute -top-2 -right-2 w-5 h-5 rounded-full flex items-center justify-center border border-[var(--accent)] bg-[var(--accent-light)] text-[var(--accent)] hover:bg-[var(--accent)] hover:text-white transition shadow-sm"
-        >
-          <X class="w-3 h-3" />
-        </button>
-      </div>
-
-      <!-- Public only: grid/list toggle -->
+    We supply:
+    - #action slot: grid/list toggle (public mode only)
+    - #extra-filters slot: TagFilter
+    - extraFiltersActive: drives the ×-badge (includes tag activity)
+    - @clear-filters: clears the tag selection when the badge is clicked
+  -->
+  <BlogsStoryToolbar
+    v-model:sort-order="sortOrder"
+    :story-titles="[]"
+    :oldest-date="oldestDate"
+    :newest-date="newestDate"
+    :date-filter="dateFilter"
+    :fetch-suggestions="fetchSuggestions"
+    :extra-filters-active="hasActiveFilters"
+    :sort-label="t('archive.sortLabel')"
+    @update:search="searchQuery = $event"
+    @update:date-filter="dateFilter = $event"
+    @clear-filters="tagIds = []"
+  >
+    <!-- Grid/list toggle (public mode only) -->
+    <template v-if="!isAdmin" #action>
       <button
-        v-if="!props.isAdmin"
-        class="w-12 h-12 flex items-center justify-center rounded-md border-2 border-foreground bg-transparent text-foreground transition-colors hover:bg-primary hover:text-primary-foreground"
+        class="w-12 h-12 flex items-center justify-center rounded-md border-2 border-[var(--foreground)] bg-transparent text-[var(--foreground)] transition-colors hover:bg-[var(--foreground)] hover:text-[var(--background)]"
         @click="viewMode = viewMode === 'grid' ? 'list' : 'grid'"
       >
         <List v-if="viewMode === 'grid'" class="w-4 h-4" />
         <LayoutGrid v-else class="w-4 h-4" />
       </button>
-    </div>
+    </template>
 
-    <!-- Filter panel -->
-    <Transition name="filter-slide">
-      <div v-if="filterOpen" class="border-t border-border">
-        <div class="page-container py-6 flex flex-col gap-6">
-          <!-- Calendar -->
-          <span
-            class="font-brand font-black text-[10px] uppercase tracking-widest text-muted-foreground"
-          >
-            {{ t("archive.calendarLabel") }}
-          </span>
-          <div class="min-w-0">
-            <Calendar
-              :key="calendarKey"
-              :oldest-date="oldestDate"
-              :model-filter="dateFilter"
-              @update:filter="dateFilter = $event"
-            />
-          </div>
-
-          <!-- Tag filter -->
-          <span
-            class="font-brand font-black text-[10px] uppercase tracking-widest text-muted-foreground"
-          >
-            {{ t("archive.tagsLabel") }}
-          </span>
-          <TagFilter />
-        </div>
+    <!-- Tag filter rendered at the bottom of the filter panel -->
+    <template #extra-filters>
+      <div class="flex flex-col gap-2">
+        <span
+          class="font-brand font-black text-[10px] uppercase tracking-widest text-muted-foreground"
+        >
+          {{ t("archive.tagsLabel") }}
+        </span>
+        <TagFilter />
       </div>
-    </Transition>
-  </div>
+    </template>
+  </BlogsStoryToolbar>
 </template>
-
-<style scoped>
-.filter-slide-enter-active,
-.filter-slide-leave-active {
-  transition:
-    opacity 0.18s ease,
-    max-height 0.22s ease;
-  overflow: hidden;
-  max-height: 900px;
-}
-.filter-slide-enter-from,
-.filter-slide-leave-to {
-  opacity: 0;
-  max-height: 0;
-}
-</style>

--- a/frontend/app/components/archive/ArchiveSearchSection.vue
+++ b/frontend/app/components/archive/ArchiveSearchSection.vue
@@ -137,6 +137,18 @@ onMounted(() => {
         />
       </div>
 
+      <!-- Sort order select -->
+      <div class="shrink-0 h-12">
+        <label class="sr-only">{{ t("archive.sortLabel") }}</label>
+        <select
+          v-model="sortOrder"
+          class="h-12 px-3 rounded bg-muted border border-border text-[10px] font-brand font-black uppercase tracking-widest text-muted-foreground focus:outline-none cursor-pointer transition-colors hover:border-foreground/30"
+        >
+          <option value="newest">{{ t("archive.sortNewest") }}</option>
+          <option value="oldest">{{ t("archive.sortOldest") }}</option>
+        </select>
+      </div>
+
       <!-- Filter toggle + badge -->
       <div class="relative">
         <button
@@ -190,22 +202,6 @@ onMounted(() => {
     <Transition name="filter-slide">
       <div v-if="filterOpen" class="border-t border-border">
         <div class="page-container py-6 flex flex-col gap-6">
-          <!-- Sort order -->
-          <div class="flex flex-col gap-2 shrink-0 pt-1 w-max">
-            <span
-              class="font-brand font-black text-[10px] uppercase tracking-widest text-muted-foreground"
-            >
-              {{ t("archive.sortLabel") }}
-            </span>
-            <select
-              v-model="sortOrder"
-              class="h-10 px-3 rounded-md bg-muted border border-border text-[10px] font-brand font-black uppercase tracking-widest text-muted-foreground focus:outline-none cursor-pointer transition-colors hover:border-foreground/30 w-max"
-            >
-              <option value="newest">{{ t("archive.sortNewest") }}</option>
-              <option value="oldest">{{ t("archive.sortOldest") }}</option>
-            </select>
-          </div>
-
           <!-- Calendar -->
           <span
             class="font-brand font-black text-[10px] uppercase tracking-widest text-muted-foreground"

--- a/frontend/app/components/blogs/StoryToolbar.vue
+++ b/frontend/app/components/blogs/StoryToolbar.vue
@@ -247,11 +247,6 @@ const hasBadge = computed(() =>
 
 /** Height class applied to interactive controls so they line up. */
 const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
-
-// Sort select hover state — CSS :hover alone can't be used because native <select>
-// keeps :focus after clicking, leaving the hover inversion stuck while the dropdown is open.
-const sortHovered = ref(false);
-const sortOpen = ref(false);
 </script>
 
 <template>
@@ -276,26 +271,63 @@ const sortOpen = ref(false);
         />
       </div>
 
-      <!-- Sort order select — same visual style as the filter button -->
-      <div class="shrink-0" :class="rowHeight">
-        <label class="sr-only">{{ sortLabel ?? t("stories.sortLabel") }}</label>
-        <select
-          v-model="activeSortOrder"
-          :class="[
-            'h-full px-5 rounded-md border-2 border-[var(--foreground)] text-[10px] font-brand font-black uppercase tracking-widest focus:outline-none cursor-pointer transition-all appearance-none',
-            sortHovered && !sortOpen
-              ? 'bg-[var(--foreground)] text-[var(--background)]'
-              : 'bg-[var(--background)] text-[var(--foreground)]',
-          ]"
-          @mouseenter="sortHovered = true"
-          @mouseleave="sortHovered = false"
-          @mousedown="sortOpen = true"
-          @blur="sortOpen = false"
+      <!-- Sort order toggle button — same visual style as the filter button -->
+      <button
+        type="button"
+        :class="['btn-outline shrink-0', rowHeight]"
+        :aria-label="
+          activeSortOrder === 'newest'
+            ? t('stories.sortNewest')
+            : t('stories.sortOldest')
+        "
+        :title="
+          activeSortOrder === 'newest'
+            ? t('stories.sortNewest')
+            : t('stories.sortOldest')
+        "
+        @click="
+          activeSortOrder = activeSortOrder === 'newest' ? 'oldest' : 'newest'
+        "
+      >
+        <!-- Newest first: bars wide→narrow + down arrow -->
+        <svg
+          v-if="activeSortOrder === 'newest'"
+          width="16"
+          height="14"
+          viewBox="0 0 16 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
         >
-          <option value="newest">{{ t("stories.sortNewest") }}</option>
-          <option value="oldest">{{ t("stories.sortOldest") }}</option>
-        </select>
-      </div>
+          <line x1="1" y1="2" x2="9" y2="2" />
+          <line x1="1" y1="6" x2="6.5" y2="6" />
+          <line x1="1" y1="10" x2="4" y2="10" />
+          <line x1="13" y1="1" x2="13" y2="13" />
+          <polyline points="10.5,10.5 13,13 15.5,10.5" />
+        </svg>
+        <!-- Oldest first: bars narrow→wide + up arrow -->
+        <svg
+          v-else
+          width="16"
+          height="14"
+          viewBox="0 0 16 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="1" y1="2" x2="4" y2="2" />
+          <line x1="1" y1="6" x2="6.5" y2="6" />
+          <line x1="1" y1="10" x2="9" y2="10" />
+          <line x1="13" y1="13" x2="13" y2="1" />
+          <polyline points="10.5,3.5 13,1 15.5,3.5" />
+        </svg>
+      </button>
 
       <!-- Filters toggle button with active-filter badge -->
       <div class="relative shrink-0">

--- a/frontend/app/components/blogs/StoryToolbar.vue
+++ b/frontend/app/components/blogs/StoryToolbar.vue
@@ -214,6 +214,18 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
         />
       </div>
 
+      <!-- Sort order select -->
+      <div class="shrink-0" :class="rowHeight">
+        <label class="sr-only">{{ t("stories.sortLabel") }}</label>
+        <select
+          v-model="sortOrder"
+          class="h-full px-3 rounded bg-muted border border-border text-[10px] font-brand font-black uppercase tracking-widest text-muted-foreground focus:outline-none cursor-pointer transition-colors hover:border-foreground/30"
+        >
+          <option value="newest">{{ t("stories.sortNewest") }}</option>
+          <option value="oldest">{{ t("stories.sortOldest") }}</option>
+        </select>
+      </div>
+
       <!-- Filters toggle button with active-filter badge -->
       <div class="relative shrink-0">
         <button
@@ -283,18 +295,6 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
     <Transition name="cal-slide">
       <div v-if="panelOpen" class="border-t border-border">
         <div class="page-container py-6 flex flex-col gap-6">
-          <!-- Sort order -->
-          <div class="flex flex-col gap-2 w-max">
-            <span class="section-label">{{ t("stories.sortLabel") }}</span>
-            <select
-              v-model="sortOrder"
-              class="h-10 px-3 rounded bg-muted border border-border text-[10px] font-brand font-black uppercase tracking-widest text-muted-foreground focus:outline-none cursor-pointer transition-colors hover:border-foreground/30 w-max"
-            >
-              <option value="newest">{{ t("stories.sortNewest") }}</option>
-              <option value="oldest">{{ t("stories.sortOldest") }}</option>
-            </select>
-          </div>
-
           <!-- Year picker — only shown when date bounds are available -->
           <div class="flex flex-col gap-2">
             <span class="section-label">{{ t("stories.filters.year") }}</span>

--- a/frontend/app/components/blogs/StoryToolbar.vue
+++ b/frontend/app/components/blogs/StoryToolbar.vue
@@ -5,59 +5,56 @@
 
   - Full-text search via SearchBar. Emits `update:search` on change.
   - A collapsible filter panel containing:
-      • Sort-order select (newest / oldest), bound via the shared `sortOrder`
-        ref from useBlogView.
-      • Year picker (YearPicker). Selecting a year emits a full-year date
-        range; deselecting clears the filter.
-      • Arbitrary date-range picker (DefaultCalendar). When the calendar
-        emits a range the active year pill is cleared, and vice-versa.
-  - A small ×-badge on the filter button when a date filter is active but the
-    panel is closed, allowing one-click reset without reopening the panel.
-  - An optional #action slot rendered flush-right in the toolbar row,
-    aligned to the same height as the search bar.
+      • Sort-order select (styled like the filter button — bordered, inverts on hover).
+      • Year range slider (YearRangeSlider). Dragging either handle sets a full-year
+        date range; resetting both handles to the full span clears the filter.
+      • Arbitrary date-range picker (DefaultCalendar). When the calendar emits a range
+        the year slider resets to full span, and vice-versa.
+  - A small ×-badge on the filter button when a date filter (or extra filter) is active
+    but the panel is closed, allowing one-click reset without reopening the panel.
+  - An optional #action slot rendered flush-right in the toolbar row.
+  - An optional #extra-filters slot rendered at the bottom of the filter panel, for
+    additional filters that don't belong to StoryToolbar itself (e.g. tag filter in
+    the archive).
 
   Props:
-  - storyTitles:      legacy prop, kept for backwards compat (unused internally).
-  - oldestDate:       ISO date string — lower bound for the calendar.
-  - newestDate:       ISO date string — upper bound for the year picker.
-  - dateFilter:       the currently active DateFilter (controlled from parent).
-  - dense:            when true the toolbar uses slightly less vertical padding.
-  - noContainer:      when true the inner row uses full width (no page-container
-                      padding/max-width). Set this when the component is already
-                      inside a page layout that handles its own padding (e.g. admin).
-  - fetchSuggestions: optional async function for autocomplete results.
-                      Defaults to the one from useBlogView so the public page
-                      works without passing the prop explicitly. Pass a custom
-                      function from a different composable (e.g. usePrintView)
-                      to reuse this toolbar in other contexts without coupling.
+  - storyTitles:          legacy prop, kept for backwards compat (unused internally).
+  - oldestDate:           ISO date string — lower bound for the calendar / year slider.
+  - newestDate:           ISO date string — upper bound for the year slider.
+  - dateFilter:           the currently active DateFilter (controlled from parent).
+  - dense:                when true the toolbar uses slightly less vertical padding.
+  - noContainer:          when true the inner row uses full width (no page-container).
+  - fetchSuggestions:     optional async function for autocomplete results.
+  - sortOrder:            optional controlled sort order (falls back to useBlogView).
+  - searchQuery:          optional controlled search query (for archive reuse).
+  - extraFiltersActive:   when true, shows the ×-badge even without a date filter.
+                          When provided, overrides the default hasDateFilter check.
+  - sortLabel:            accessible label for the sort select (sr-only).
 
   Emits:
-  - update:search      — debounced search string
-  - update:dateFilter  — DateFilter object (after/before ISO strings or empty)
+  - update:search         — debounced search string
+  - update:dateFilter     — DateFilter object (after/before ISO strings or empty)
+  - update:sortOrder      — sort order change (only when sortOrder prop is provided)
+  - clear-filters         — fired when the ×-badge is clicked (archive can use this
+                            to also clear its tag filter)
 -->
 
 <script lang="ts" setup>
 import { useBlogView } from "~/composables/blogs/useBlogView";
 import type { DateFilter } from "~/types/DateFilter";
 import type { SearchSuggestion } from "~/components/SearchBar.vue";
+import { isoYear } from "~/utils/formatters";
 
 const { t } = useI18n();
 
-// Pull shared filter state (sortOrder, searchQuery) from the blog view store.
-// These are module-level refs so changes here are reflected everywhere the
-// composable is used (public page, admin list, etc.).
-const {
-  sortOrder,
-  searchQuery,
-  fetchSuggestions: defaultFetchSuggestions,
-} = useBlogView();
+const blogView = useBlogView();
 
 const props = defineProps<{
   /** Kept for backwards compatibility — not used internally. */
   storyTitles: string[];
-  /** ISO date string: oldest story date, passed to DefaultCalendar. */
+  /** ISO date string: oldest story date, passed to DefaultCalendar / YearRangeSlider. */
   oldestDate: string;
-  /** ISO date string: newest story date, used by YearPicker to build the year list. */
+  /** ISO date string: newest story date, used by YearRangeSlider to build the year range. */
   newestDate: string;
   /** Currently active date filter (controlled from the parent). */
   dateFilter: DateFilter;
@@ -70,122 +67,182 @@ const props = defineProps<{
   noContainer?: boolean;
   /**
    * Custom autocomplete function. Defaults to the blog-view implementation.
-   * Pass a different function to reuse this toolbar for other entity types
-   * (e.g. prints, productions) without coupling to useBlogView.
    */
   fetchSuggestions?: (
     query: string,
     limit: number,
   ) => Promise<SearchSuggestion[]>;
+  /**
+   * Optional controlled sort order. When provided, the toolbar emits
+   * `update:sortOrder` instead of mutating useBlogView directly.
+   * Falls back to useBlogView.sortOrder when omitted.
+   */
+  sortOrder?: "newest" | "oldest";
+  /**
+   * Optional controlled search query (for reuse outside the blog context).
+   * When provided, the SearchBar shows this value and emits changes via
+   * `update:search` without touching useBlogView.searchQuery.
+   */
+  searchQuery?: string;
+  /**
+   * When provided, this value controls whether the ×-badge is shown instead
+   * of the default `hasDateFilter` check. Pass `true` when the parent has
+   * additional active filters (e.g. tags in the archive).
+   */
+  extraFiltersActive?: boolean;
+  /** Accessible label for the sort <select>. */
+  sortLabel?: string;
 }>();
 
 const emit = defineEmits<{
-  (e: "update:search", query: string): void;
-  (e: "update:dateFilter", filter: DateFilter): void;
+  "update:search": [query: string];
+  "update:dateFilter": [filter: DateFilter];
+  "update:sortOrder": [val: "newest" | "oldest"];
+  /** Fired when the ×-badge is clicked so the parent can clear its own filters. */
+  "clear-filters": [];
 }>();
 
-// Use the prop if provided, otherwise fall back to the blog-view default.
-const resolvedFetchSuggestions = computed(
-  () => props.fetchSuggestions ?? defaultFetchSuggestions,
+// ——— Sort order ———
+// Controlled via prop when provided; falls back to the shared blogView ref.
+const activeSortOrder = computed({
+  get: () => props.sortOrder ?? blogView.sortOrder.value,
+  set: (val: "newest" | "oldest") => {
+    emit("update:sortOrder", val);
+    if (props.sortOrder === undefined) {
+      blogView.sortOrder.value = val;
+    }
+  },
+});
+
+// ——— Search query ———
+// Local ref that either stays in sync with the prop (archive/controlled mode) or
+// with useBlogView.searchQuery (blog/admin mode — backward compat).
+const localSearch = ref(
+  props.searchQuery !== undefined
+    ? props.searchQuery
+    : blogView.searchQuery.value,
 );
 
-// Filter panel state
+watch(
+  () => props.searchQuery,
+  (v) => {
+    if (v !== undefined && v !== localSearch.value) localSearch.value = v;
+  },
+);
 
+watch(localSearch, (val) => {
+  emit("update:search", val);
+  if (props.searchQuery === undefined) {
+    blogView.searchQuery.value = val;
+  }
+});
+
+// ——— Suggestions ———
+const resolvedFetchSuggestions = computed(
+  () => props.fetchSuggestions ?? blogView.fetchSuggestions,
+);
+
+// ——— Filter panel ———
 const panelOpen = ref(false);
-
-/** Currently selected year pill (null = none selected). */
-const selectedYear = ref<number | null>(null);
-
-/**
- * Key that is bumped whenever we want DefaultCalendar to fully re-mount
- * and reset its internal state (e.g. after a year pill click clears the range).
- */
 const calendarKey = ref(0);
 
-/**
- * Guard flag: when we update the calendar key after a year-pill click the
- * calendar will emit an empty filter on mount. We skip that one emission so
- * the year-based filter is not immediately cleared.
- */
+// Guard: prevent the calendar's re-mount emission from overwriting the year filter.
 const skipNextCalendarEmit = ref(false);
 
-// Forward search string to parent whenever it changes.
-watch(searchQuery, (val) => emit("update:search", val));
+// ——— Year range slider ———
+const oldestYear = computed(() => {
+  const y = isoYear(props.oldestDate);
+  return !isNaN(y) && y > 0 ? y : new Date().getFullYear() - 10;
+});
+const newestYear = computed(() => {
+  const y = isoYear(props.newestDate);
+  return !isNaN(y) && y > 0 ? y : new Date().getFullYear();
+});
 
-// Year picker
+const yearRange = ref<[number, number]>([oldestYear.value, newestYear.value]);
 
-/**
- * Called by YearPicker when a year pill is clicked or cleared.
- * - Selecting a year: emit a full-year date range and reset the calendar.
- * - Clearing (year = null): emit an empty filter and reset the calendar.
- */
-function onYearUpdate(year: number | null) {
-  if (year === null) {
-    selectedYear.value = null;
-    calendarKey.value++;
+// Initialise / reset the slider when the year bounds are loaded asynchronously.
+// Only resets if the slider was still at the previous full range (user hasn't moved it).
+watch([oldestYear, newestYear], ([o, n], [prevO, prevN]) => {
+  const [from, to] = yearRange.value;
+  if (from === prevO && to === prevN) {
+    yearRange.value = [o, n];
+  }
+});
+
+function onYearRangeUpdate([from, to]: [number, number]) {
+  yearRange.value = [from, to];
+  const isFullRange = from === oldestYear.value && to === newestYear.value;
+  if (isFullRange) {
     emit("update:dateFilter", {});
   } else {
-    selectedYear.value = year;
-    // Prevent the calendar's mount-emit from overwriting our year filter.
     skipNextCalendarEmit.value = true;
     emit("update:dateFilter", {
-      after: `${year}-01-01`,
-      before: `${year}-12-31`,
+      after: `${from}-01-01`,
+      before: `${to}-12-31`,
     });
     calendarKey.value++;
   }
 }
 
 // Calendar
-
-/**
- * Called by DefaultCalendar whenever its internal selection changes.
- * Clears the active year pill so the two controls don't conflict.
- */
 function onCalendarFilter(filter: DateFilter) {
-  // Skip the emission that is triggered by the calendar re-mounting after a
-  // year-pill click (see skipNextCalendarEmit above).
   if (skipNextCalendarEmit.value) {
     skipNextCalendarEmit.value = false;
     return;
   }
-  selectedYear.value = null;
+  // Calendar used → reset year slider to full span (the two controls are mutually exclusive)
+  yearRange.value = [oldestYear.value, newestYear.value];
   emit("update:dateFilter", filter);
 }
 
-/** Clear all date-based filters and reset both picker controls. */
 function clearAllFilters() {
-  selectedYear.value = null;
+  yearRange.value = [oldestYear.value, newestYear.value];
+  skipNextCalendarEmit.value = true;
   calendarKey.value++;
   emit("update:dateFilter", {});
+  emit("clear-filters");
 }
 
-// Keep `selectedYear` in sync when the parent clears or sets a date filter
-// from the outside (e.g. resetting all filters from ArchiveSearchSection).
+// Keep yearRange in sync when the parent clears or changes dateFilter externally.
 watch(
   () => props.dateFilter,
   (f) => {
     if (!f.after && !f.before) {
-      selectedYear.value = null;
+      yearRange.value = [oldestYear.value, newestYear.value];
       return;
     }
-    // Detect a full-year filter set via the year picker and reflect it back.
-    const isFullYear =
-      f.after?.endsWith("-01-01") &&
-      f.before?.endsWith("-12-31") &&
-      f.after.substring(0, 4) === f.before.substring(0, 4);
-    if (!isFullYear) {
-      selectedYear.value = null;
+    if (f.after?.endsWith("-01-01") && f.before?.endsWith("-12-31")) {
+      const from = parseInt(f.after.substring(0, 4));
+      const to = parseInt(f.before.substring(0, 4));
+      if (!isNaN(from) && !isNaN(to)) {
+        yearRange.value = [from, to];
+      }
+    } else if (!f.after) {
+      // Only a `before` bound (e.g. the archive default) → no year range filter
+      yearRange.value = [oldestYear.value, newestYear.value];
     }
   },
   { deep: true },
 );
 
-// Derived UI state
+// ——— Derived UI state ———
 
 /** True when any date filter is currently active. */
 const hasDateFilter = computed(
   () => !!(props.dateFilter.after || props.dateFilter.before),
+);
+
+/**
+ * Whether to show the ×-badge.
+ * If `extraFiltersActive` is explicitly provided, use it as the sole source of truth
+ * (the parent knows about all active filters including non-date ones like tags).
+ * Otherwise fall back to hasDateFilter.
+ */
+const hasBadge = computed(() =>
+  props.extraFiltersActive !== undefined
+    ? props.extraFiltersActive
+    : hasDateFilter.value,
 );
 
 /** Height class applied to interactive controls so they line up. */
@@ -205,7 +262,7 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
       <!-- Search input -->
       <div :class="['flex-1 min-w-0', rowHeight]">
         <SearchBar
-          v-model="searchQuery"
+          v-model="localSearch"
           :fetch-suggestions="resolvedFetchSuggestions"
           :limit="15"
           :scroll-limit="5"
@@ -214,12 +271,12 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
         />
       </div>
 
-      <!-- Sort order select -->
+      <!-- Sort order select — same visual style as the filter button -->
       <div class="shrink-0" :class="rowHeight">
-        <label class="sr-only">{{ t("stories.sortLabel") }}</label>
+        <label class="sr-only">{{ sortLabel ?? t("stories.sortLabel") }}</label>
         <select
-          v-model="sortOrder"
-          class="h-full px-3 rounded bg-muted border border-border text-[10px] font-brand font-black uppercase tracking-widest text-muted-foreground focus:outline-none cursor-pointer transition-colors hover:border-foreground/30"
+          v-model="activeSortOrder"
+          class="sort-select h-full px-5 rounded-md border-2 border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] text-[10px] font-brand font-black uppercase tracking-widest focus:outline-none cursor-pointer transition-all appearance-none"
         >
           <option value="newest">{{ t("stories.sortNewest") }}</option>
           <option value="oldest">{{ t("stories.sortOldest") }}</option>
@@ -260,10 +317,10 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
 
         <!-- ×-badge: one-click clear without opening the panel -->
         <button
-          v-if="hasDateFilter"
+          v-if="hasBadge"
           class="absolute -top-2 -right-2 w-5 h-5 rounded-full flex items-center justify-center border border-[var(--blog-purple-strong)] bg-[var(--blog-purple-ghost)] text-[var(--blog-purple-strong)] hover:bg-[var(--blog-purple-strong)] hover:text-white transition shadow-sm"
-          @click.stop="clearAllFilters"
           :aria-label="t('stories.filters.clear')"
+          @click.stop="clearAllFilters"
         >
           <svg
             width="8"
@@ -284,7 +341,7 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
 
       <!--
         Action slot — rendered at the same height as the search bar.
-        Example: "New story" button in the admin toolbar.
+        Example: grid/list toggle in the archive toolbar.
       -->
       <div v-if="$slots.action" class="shrink-0" :class="rowHeight">
         <slot name="action" />
@@ -295,14 +352,14 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
     <Transition name="cal-slide">
       <div v-if="panelOpen" class="border-t border-border">
         <div class="page-container py-6 flex flex-col gap-6">
-          <!-- Year picker — only shown when date bounds are available -->
-          <div class="flex flex-col gap-2">
+          <!-- Year range slider — only shown when date bounds are available -->
+          <div v-if="oldestDate && newestDate" class="flex flex-col gap-2">
             <span class="section-label">{{ t("stories.filters.year") }}</span>
-            <YearPicker
-              :model-value="selectedYear"
-              :oldest-date="oldestDate"
-              :newest-date="newestDate"
-              @update:model-value="onYearUpdate"
+            <YearRangeSlider
+              :model-value="yearRange"
+              :oldest-year="oldestYear"
+              :newest-year="newestYear"
+              @update:model-value="onYearRangeUpdate"
             />
           </div>
 
@@ -312,8 +369,8 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
               t("stories.filters.dateRange")
             }}</span>
             <!--
-              :key="calendarKey" forces a full re-mount whenever the year picker
-              changes so DefaultCalendar resets its own internal state.
+              :key="calendarKey" forces a full re-mount whenever the year range
+              slider changes so DefaultCalendar resets its own internal state.
             -->
             <DefaultCalendar
               :key="calendarKey"
@@ -322,6 +379,9 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
               @update:filter="onCalendarFilter"
             />
           </div>
+
+          <!-- Extra filters slot (e.g. TagFilter in the archive) -->
+          <slot name="extra-filters" />
         </div>
       </div>
     </Transition>

--- a/frontend/app/components/blogs/StoryToolbar.vue
+++ b/frontend/app/components/blogs/StoryToolbar.vue
@@ -247,6 +247,11 @@ const hasBadge = computed(() =>
 
 /** Height class applied to interactive controls so they line up. */
 const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
+
+// Sort select hover state — CSS :hover alone can't be used because native <select>
+// keeps :focus after clicking, leaving the hover inversion stuck while the dropdown is open.
+const sortHovered = ref(false);
+const sortOpen = ref(false);
 </script>
 
 <template>
@@ -276,7 +281,16 @@ const rowHeight = computed(() => (props.dense ? "h-11" : "h-12"));
         <label class="sr-only">{{ sortLabel ?? t("stories.sortLabel") }}</label>
         <select
           v-model="activeSortOrder"
-          class="sort-select h-full px-5 rounded-md border-2 border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] text-[10px] font-brand font-black uppercase tracking-widest focus:outline-none cursor-pointer transition-all appearance-none"
+          :class="[
+            'h-full px-5 rounded-md border-2 border-[var(--foreground)] text-[10px] font-brand font-black uppercase tracking-widest focus:outline-none cursor-pointer transition-all appearance-none',
+            sortHovered && !sortOpen
+              ? 'bg-[var(--foreground)] text-[var(--background)]'
+              : 'bg-[var(--background)] text-[var(--foreground)]',
+          ]"
+          @mouseenter="sortHovered = true"
+          @mouseleave="sortHovered = false"
+          @mousedown="sortOpen = true"
+          @blur="sortOpen = false"
         >
           <option value="newest">{{ t("stories.sortNewest") }}</option>
           <option value="oldest">{{ t("stories.sortOldest") }}</option>

--- a/frontend/app/composables/useArchiveView.ts
+++ b/frontend/app/composables/useArchiveView.ts
@@ -38,6 +38,7 @@ const totalPages = ref(1);
 // Data/loading state
 const loading = ref(false);
 const oldestDate = ref("");
+const newestDate = ref(getToday());
 
 export function useArchiveView() {
   const { getAll } = useProductionApi();
@@ -100,6 +101,7 @@ export function useArchiveView() {
 
     loading,
     oldestDate,
+    newestDate,
 
     fetchSuggestions,
   };

--- a/frontend/locales/nl.json
+++ b/frontend/locales/nl.json
@@ -569,7 +569,7 @@
       "no-results": "Geen series gevonden",
       "link": "Koppelen",
       "linked": "Gekoppeld",
-      "unlink": "Onktoppelen",
+      "unlink": "Ontkoppelen",
       "delete": "Verwijder"
     }
   },

--- a/frontend/tests/composables/useAuth.spec.ts
+++ b/frontend/tests/composables/useAuth.spec.ts
@@ -13,13 +13,13 @@ vi.mock("#app", async (importOriginal) => {
 });
 
 const mockFetch = vi.fn();
-vi.stubGlobal("$fetch", mockFetch);
 
 beforeEach(() => {
   mockFetch.mockReset();
   vi.clearAllMocks();
   sessionStorage.clear();
   vi.stubGlobal("navigateTo", vi.fn());
+  vi.stubGlobal("$fetch", mockFetch);
 });
 
 afterEach(() => {

--- a/frontend/tests/composables/useAuth.spec.ts
+++ b/frontend/tests/composables/useAuth.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useAuth } from "../../app/composables/useAuth";
 
 vi.mock("#app", async (importOriginal) => {
@@ -14,12 +14,16 @@ vi.mock("#app", async (importOriginal) => {
 
 const mockFetch = vi.fn();
 vi.stubGlobal("$fetch", mockFetch);
-vi.stubGlobal("navigateTo", vi.fn());
 
 beforeEach(() => {
   mockFetch.mockReset();
   vi.clearAllMocks();
   sessionStorage.clear();
+  vi.stubGlobal("navigateTo", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("useAuth", () => {

--- a/frontend/tests/composables/useAuth.spec.ts
+++ b/frontend/tests/composables/useAuth.spec.ts
@@ -14,6 +14,7 @@ vi.mock("#app", async (importOriginal) => {
 
 const mockFetch = vi.fn();
 vi.stubGlobal("$fetch", mockFetch);
+vi.stubGlobal("navigateTo", vi.fn());
 
 beforeEach(() => {
   mockFetch.mockReset();


### PR DESCRIPTION
## 🎯 MAIN GOAL
placed the sort (new to ol or old to new) out of the filter section, next to the search bar

## 🔍 HOW TO TEST
1. check the pages with dates (archive/stories / admin-archive / admin-stories) and check if the sort isn't visible in the filter-component but is visible next to the searchbar

## 📸 SCREENSHOTS (if necessary):

## ✅ CLOSED ISSUES
- #454 